### PR TITLE
use .toString() instead of casting to String in StringType

### DIFF
--- a/moor/lib/src/types/sql_types.dart
+++ b/moor/lib/src/types/sql_types.dart
@@ -42,7 +42,7 @@ class StringType extends SqlType<String> {
   const StringType();
 
   @override
-  String mapFromDatabaseResponse(response) => response.toString();
+  String mapFromDatabaseResponse(response) => response?.toString();
 
   @override
   String mapToSqlConstant(String content) {

--- a/moor/lib/src/types/sql_types.dart
+++ b/moor/lib/src/types/sql_types.dart
@@ -42,7 +42,7 @@ class StringType extends SqlType<String> {
   const StringType();
 
   @override
-  String mapFromDatabaseResponse(response) => response as String;
+  String mapFromDatabaseResponse(response) => response.toString();
 
   @override
   String mapToSqlConstant(String content) {


### PR DESCRIPTION
This solves the problem of columns with mixed types as described in #69 