### PR TITLE
Fix version solving fail for extras/encryption

### DIFF
--- a/extras/encryption/pubspec.yaml
+++ b/extras/encryption/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.4.0 <3.0.0'
 
 dependencies:
-  moor: ^1.6.0
+  moor: ^2.0.0
   sqflite:
     git:
       url: https://www.github.com/davidmartos96/sqflite_sqlcipher.git


### PR DESCRIPTION
Version solving fails with the newest release of moor (2.0.0). This only updates the moor version in pubspec.yaml as the mirrored moor_flutter.dart has not changed except for the removal of functionality that was not supported by encrypted_moor.dart.