### PR TITLE
Fix typo: now to know

### DIFF
--- a/docs/content/en/docs/Getting started/writing_queries.md
+++ b/docs/content/en/docs/Getting started/writing_queries.md
@@ -58,7 +58,7 @@ You can also reverse the order by setting the `mode` property of the `OrderingTe
 `OrderingMode.desc`.
 
 ### Single values
-If you now a query is never going to return more than one row, wrapping the result in a `List`
+If you know a query is never going to return more than one row, wrapping the result in a `List`
 can be tedious. Moor lets you work around that with `getSingle` and `watchSingle`:
 ```dart
 Stream<TodoEntry> entryById(int id) {


### PR DESCRIPTION
While reading through the documentation, I noticed this typo where you meant to use the word `know` instead of `now`.