### PR TITLE
add more ignore_for_file rules to the moor_generator

### DIFF
--- a/moor/test/data/tables/custom_tables.g.dart
+++ b/moor/test/data/tables/custom_tables.g.dart
@@ -966,6 +966,13 @@ abstract class _$CustomTablesDb extends GeneratedDatabase {
         readsFrom: {config}).map(_rowToReadRowIdResult);
   }
 
+  Selectable<int> test() {
+    return customSelectQuery(
+        'WITH RECURSIVE\n  cnt(x) AS (\n    SELECT 1\n      UNION ALL\n      SELECT x+1 FROM cnt\n      LIMIT 1000000\n    )\n  SELECT x FROM cnt',
+        variables: [],
+        readsFrom: {}).map((QueryRow row) => row.readInt('x'));
+  }
+
   Future<int> writeConfig(String key, String value) {
     return customInsert(
       'REPLACE INTO config VALUES (:key, :value)',

--- a/moor/test/data/tables/tables.moor
+++ b/moor/test/data/tables/tables.moor
@@ -32,3 +32,12 @@ readMultiple: SELECT * FROM config WHERE config_key IN ? ORDER BY $clause;
 readDynamic: SELECT * FROM config WHERE $predicate;
 
 readRowId: SELECT oid, * FROM config WHERE _rowid_ = $expr;
+
+cfeTest: WITH RECURSIVE
+  cnt(x) AS (
+    SELECT 1
+      UNION ALL
+      SELECT x+1 FROM cnt
+      LIMIT 1000000
+    )
+  SELECT x FROM cnt;

--- a/moor_generator/CHANGELOG.md
+++ b/moor_generator/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.1
+
+- Fix a crash when using common table expressions in custom statements
+- Don't use a moor specific caching graph across build steps
+
 ## 2.1.0
 
 - Accept inheritance in table definitions (e.g. if an abstract class declared as `IntColumn get foo => integer()()`,

--- a/moor_generator/lib/src/analyzer/runner/task.dart
+++ b/moor_generator/lib/src/analyzer/runner/task.dart
@@ -133,6 +133,7 @@ class Task {
         }
         break;
       default:
+        assert(false, 'Unknown file type ${file.type}');
         break;
     }
 

--- a/moor_generator/lib/src/analyzer/sql_queries/affected_tables_visitor.dart
+++ b/moor_generator/lib/src/analyzer/sql_queries/affected_tables_visitor.dart
@@ -18,9 +18,9 @@ class ReferencedTablesVisitor extends RecursiveVisitor<void> {
   @override
   void visitQueryable(Queryable e) {
     if (e is TableReference) {
-      final table = e.resolved as Table;
-      if (table != null) {
-        foundTables.add(table);
+      final resolved = e.resolved;
+      if (resolved != null && resolved is Table) {
+        foundTables.add(resolved);
       }
     }
 

--- a/moor_generator/lib/src/analyzer/sql_queries/query_handler.dart
+++ b/moor_generator/lib/src/analyzer/sql_queries/query_handler.dart
@@ -156,8 +156,13 @@ class QueryHandler {
     } else if (c is ExpressionColumn) {
       final expression = c.expression;
       if (expression is Reference) {
-        return expression.resolved as TableColumn;
+        final resolved = expression.resolved;
+        if (resolved is Column) {
+          return _toTableColumn(resolved);
+        }
       }
+    } else if (c is DelegatedColumn) {
+      return _toTableColumn(c.innerColumn);
     }
     return null;
   }

--- a/moor_generator/lib/src/backends/build/build_backend.dart
+++ b/moor_generator/lib/src/backends/build/build_backend.dart
@@ -3,7 +3,6 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart' hide log;
 import 'package:build/build.dart' as build show log;
 import 'package:logging/logging.dart';
-import 'package:moor_generator/src/analyzer/runner/file_graph.dart';
 import 'package:moor_generator/src/backends/backend.dart';
 
 class BuildBackend extends Backend {
@@ -52,14 +51,5 @@ class BuildBackendTask extends BackendTask {
   @override
   Future<bool> exists(Uri uri) {
     return step.canRead(_resolve(uri));
-  }
-
-  Future finish(FoundFile inputFile) async {
-    // the result could be cached if it was calculated in a previous build step.
-    // we need to can canRead so that the build package can calculate the
-    // dependency graph correctly
-    for (var transitiveImport in backend.session.fileGraph.crawl(inputFile)) {
-      await step.canRead(_resolve(transitiveImport.uri));
-    }
   }
 }

--- a/moor_generator/lib/src/backends/build/generators/moor_generator.dart
+++ b/moor_generator/lib/src/backends/build/generators/moor_generator.dart
@@ -14,7 +14,7 @@ class MoorGenerator extends Generator implements BaseGenerator {
 
     if (parsed.declaredDatabases.isNotEmpty) {
       writer.leaf().write(
-          '// ignore_for_file: unnecessary_brace_in_string_interps, unnecessary_this\n');
+          '// ignore_for_file: unnecessary_brace_in_string_interps, unnecessary_this, always_specify_types, implicit_dynamic_parameter, sort_constructors_first, implicit_dynamic_map_literal, avoid_renaming_method_parameters, sort_constructors_first, lines_longer_than_80_chars\n');
     }
 
     for (var db in parsed.declaredDatabases) {

--- a/moor_generator/lib/src/backends/build/moor_builder.dart
+++ b/moor_generator/lib/src/backends/build/moor_builder.dart
@@ -8,8 +8,6 @@ import 'package:source_gen/source_gen.dart';
 
 part 'options.dart';
 
-final backendResource = Resource(() => BuildBackend());
-
 class MoorBuilder extends SharedPartBuilder {
   final MoorOptions options;
 
@@ -36,7 +34,7 @@ class MoorBuilder extends SharedPartBuilder {
   Writer createWriter() => Writer(options);
 
   Future<ParsedDartFile> analyzeDartFile(BuildStep step) async {
-    final backend = await step.fetchResource(backendResource);
+    final backend = BuildBackend();
     final backendTask = backend.createTask(step);
     final session = backend.session;
 
@@ -45,8 +43,6 @@ class MoorBuilder extends SharedPartBuilder {
     await task.runTask();
 
     task.printErrors();
-
-    await backendTask.finish(input);
 
     return input.currentResult as ParsedDartFile;
   }

--- a/moor_generator/pubspec.yaml
+++ b/moor_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: moor_generator
 description: Dev-dependency to generate table and dataclasses together with the moor package.
-version: 2.1.0
+version: 2.1.1
 repository: https://github.com/simolus3/moor
 homepage: https://moor.simonbinder.eu/
 issue_tracker: https://github.com/simolus3/moor/issues

--- a/moor_generator/test/analyzer/moor/cfe_test.dart
+++ b/moor_generator/test/analyzer/moor/cfe_test.dart
@@ -1,0 +1,66 @@
+import 'package:build/build.dart';
+import 'package:moor_generator/src/analyzer/runner/file_graph.dart';
+import 'package:moor_generator/src/analyzer/runner/results.dart';
+import 'package:moor_generator/src/analyzer/runner/task.dart';
+import 'package:moor_generator/src/analyzer/session.dart';
+import 'package:moor_generator/src/model/specified_column.dart';
+import 'package:moor_generator/src/model/sql_query.dart';
+import 'package:test/test.dart';
+
+import '../../utils/test_backend.dart';
+
+void main() {
+  TestBackend backend;
+  MoorSession session;
+  Task task;
+
+  setUpAll(() {
+    backend = TestBackend(
+      {
+        AssetId.parse('foo|lib/test.moor'): r'''
+test:
+WITH RECURSIVE
+  cnt(x) AS (
+    SELECT 1
+    UNION ALL
+    SELECT x+1 FROM cnt
+    LIMIT 1000000
+  )
+  SELECT x FROM cnt;
+         ''',
+      },
+    );
+    session = backend.session;
+  });
+
+  setUp(() async {
+    final backendTask = backend.startTask(Uri.parse('package:foo/test.moor'));
+    task = session.startTask(backendTask);
+    await task.runTask();
+  });
+
+  tearDownAll(() {
+    backend.finish();
+  });
+
+  test('recognizes CFE clause', () {
+    final file = session.registerFile(Uri.parse('package:foo/test.moor'));
+
+    expect(file.state, FileState.analyzed);
+    expect(file.errors.errors, isEmpty);
+
+    final result = file.currentResult as ParsedMoorFile;
+    final query = result.resolvedQueries.single as SqlSelectQuery;
+
+    expect(query.name, 'test');
+    expect(query.variables, isEmpty);
+    expect(query.declaredInMoorFile, isTrue);
+    expect(query.readsFrom, isEmpty);
+
+    final resultSet = query.resultSet;
+    expect(resultSet.singleColumn, isTrue);
+    expect(resultSet.needsOwnClass, isFalse);
+    expect(resultSet.columns.map(resultSet.dartNameFor), ['x']);
+    expect(resultSet.columns.map((c) => c.type), [ColumnType.integer]);
+  });
+}

--- a/sqlparser/lib/src/ast/common/queryables.dart
+++ b/sqlparser/lib/src/ast/common/queryables.dart
@@ -31,6 +31,10 @@ abstract class TableOrSubquery extends Queryable {}
 ///
 /// This is both referencable (if we have SELECT * FROM table t), other parts
 /// of the select statement can access "t") and a reference owner (the table).
+///
+/// Note that this doesn't necessarily resolve to a result set. It could also
+/// resolve to a common table expression or anything else defining a result
+/// set.
 class TableReference extends TableOrSubquery
     with ReferenceOwner
     implements Renamable, ResolvesToResultSet, VisibleToChildren {

--- a/sqlparser/test/analysis/common_table_expressions.dart
+++ b/sqlparser/test/analysis/common_table_expressions.dart
@@ -55,8 +55,10 @@ void main() {
 
     expect(context.errors, isEmpty);
     final select = context.root as SelectStatement;
-    final column = context.typeOf(select.resolvedColumns.single);
+    final column = select.resolvedColumns.single;
+    final type = context.typeOf(column);
 
-    expect(column.type, const ResolvedType(type: BasicType.int));
+    expect(type.type, const ResolvedType(type: BasicType.int));
+    expect(column.name, 'x');
   });
 }


### PR DESCRIPTION
The current ignore_for file rules do not counteract the linter rules used in the Flutter SDK [link](https://github.com/flutter/flutter/blob/master/analysis_options.yaml) and subsequently the linter rules in my project. The following change addresses this issue by adding additional linter rules to the moor generator. 

In the future, it may be worth addressing these linter warnings directly by adapting the code generator to generate code that adheres to these new linter rules if possible.

Thanks.