### PR TITLE
Fix table not found exception.

### DIFF
--- a/moor/lib/src/web/web_db.dart
+++ b/moor/lib/src/web/web_db.dart
@@ -68,6 +68,7 @@ class _WebDelegate extends DatabaseDelegate {
   @override
   Future<void> runCustom(String statement, List args) {
     _db.runWithArgs(statement, args);
+    _storeDb();
     return Future.value();
   }
 


### PR DESCRIPTION
We'll get table not found exception if there is no data in db because db is not stored after creating tables.

Reproduce steps:
1. select any table and keep tables empty.
2. refresh page.
