### PR TITLE
Generate $-variables should generate fully qualified columns 

### DIFF
--- a/moor/lib/src/runtime/api/query_engine.dart
+++ b/moor/lib/src/runtime/api/query_engine.dart
@@ -302,8 +302,11 @@ mixin QueryEngine on DatabaseConnectionUser {
 
   /// Will be used by generated code to resolve inline Dart expressions in sql.
   @protected
-  GenerationContext $write(Component component) {
+  GenerationContext $write(Component component, {bool hasMultipleTables: null}) {
     final context = GenerationContext.fromDb(this);
+    if (hasMultipleTables != null) {
+      context.hasMultipleTables = hasMultipleTables;
+    }
 
     // we don't want ORDER BY clauses to write the ORDER BY tokens because those
     // are already declared in sql


### PR DESCRIPTION
Part of a fix for #287 

Last bit is to add `hasMultipleTables: true` to the generated query.
```
  Selectable<Item> <query>(
      Expression<bool, BoolType> predicate, OrderBy order) {
    final generatedpredicate = $write(predicate, hasMultipleTables: true);
    final generatedorder = $write(order, hasMultipleTables: true);
    return customSelectQuery(
       <sql>,
        variables: [
          ...generatedpredicate.introducedVariables,
          ...generatedorder.introducedVariables
        ],
        readsFrom: {
          <tables>
        }).map(_rowToItem);
  }
```

I wasn't able to figure out how to do that