### PR TITLE
Members in the generated DataClass with an annotation

### DIFF
--- a/moor/lib/src/dsl/table.dart
+++ b/moor/lib/src/dsl/table.dart
@@ -123,3 +123,13 @@ class DataClassName {
   /// {@macro moor:custom_data_class}
   const DataClassName(this.name);
 }
+
+/// A class to to be used as an annotation on members of the [Table] class
+class ClassVariable
+{
+	/// Constructor
+	const ClassVariable();
+}
+
+/// define the annotation
+const classVariable = ClassVariable();

--- a/moor_generator/lib/src/analyzer/dart/parser.dart
+++ b/moor_generator/lib/src/analyzer/dart/parser.dart
@@ -14,6 +14,7 @@ import 'package:moor_generator/src/utils/type_utils.dart';
 import 'package:recase/recase.dart';
 import 'package:source_gen/source_gen.dart';
 
+part 'variable_parser.dart';
 part 'column_parser.dart';
 part 'table_parser.dart';
 part 'use_dao_parser.dart';
@@ -21,12 +22,14 @@ part 'use_moor_parser.dart';
 
 class MoorDartParser {
   final ParseDartStep step;
-
+  
   ColumnParser _columnParser;
+  VariableParser _variableParser;
   TableParser _tableParser;
 
   MoorDartParser(this.step) {
     _columnParser = ColumnParser(this);
+	_variableParser = VariableParser(this);
     _tableParser = TableParser(this);
   }
 
@@ -37,6 +40,10 @@ class MoorDartParser {
   Future<MoorColumn> parseColumn(
       MethodDeclaration declaration, Element element) {
     return Future.value(_columnParser.parse(declaration, element));
+  }
+
+  Future<MoorVariable> parseVariable(PropertyInducingElement element) {
+    return Future.value(_variableParser.parse(element));
   }
 
   @visibleForTesting

--- a/moor_generator/lib/src/analyzer/dart/variable_parser.dart
+++ b/moor_generator/lib/src/analyzer/dart/variable_parser.dart
@@ -1,0 +1,37 @@
+part of 'parser.dart';
+
+/// Parses a single column defined in a Dart table. These columns are a chain
+/// or [MethodInvocation]s. An example getter might look like this:
+/// ```dart
+/// IntColumn get id => integer().autoIncrement()();
+/// ```
+/// The last call `()` is a [FunctionExpressionInvocation], the entries for
+/// before that (in this case `autoIncrement()` and `integer()` are a)
+/// [MethodInvocation]. We work our way through that syntax until we hit a
+/// method that starts the chain (contained in [starters]). By visiting all
+/// the invocations on our way, we can extract the constraint for the column
+/// (e.g. its name, whether it has auto increment, is a primary key and so on).
+class VariableParser {
+  final MoorDartParser base;
+
+  VariableParser(this.base);
+
+  MoorVariable parse(PropertyInducingElement element) {
+    ParsedLibraryResult parsedLibResult = element.session.getParsedLibraryByElement(element.library);
+    ElementDeclarationResult elDeclarationResult = parsedLibResult.getElementDeclaration(element);
+
+	String value;
+
+	final parts = elDeclarationResult.node.toSource().split("= ");
+	if(parts.length == 2){
+		value = parts[1];
+	}
+
+    return MoorVariable(
+      type: element.type.name,
+      name: element.name,
+	  value: value,
+      declaration: DartColumnDeclaration(element, base.step.file),
+    );
+  }
+}

--- a/moor_generator/lib/src/model/model.dart
+++ b/moor_generator/lib/src/model/model.dart
@@ -1,5 +1,6 @@
 export 'base_entity.dart';
 export 'column.dart';
+export 'variable.dart';
 export 'database.dart';
 export 'declarations/declaration.dart';
 export 'sources.dart';

--- a/moor_generator/lib/src/model/table.dart
+++ b/moor_generator/lib/src/model/table.dart
@@ -6,6 +6,7 @@ import 'package:sqlparser/sqlparser.dart';
 
 import 'base_entity.dart';
 import 'column.dart';
+import 'variable.dart';
 import 'declarations/declaration.dart';
 
 /// A parsed table, declared in code by extending `Table` and referencing that
@@ -34,6 +35,9 @@ class MoorTable implements MoorSchemaEntity {
 
   /// The columns declared in this table.
   final List<MoorColumn> columns;
+
+  /// The variables declared in this table.
+  final List<MoorVariable> variables;
 
   /// The name of this table when stored in the database
   final String sqlName;
@@ -102,6 +106,7 @@ class MoorTable implements MoorSchemaEntity {
   MoorTable({
     this.fromClass,
     this.columns,
+	this.variables,
     this.sqlName,
     this.dartTypeName,
     this.primaryKey,

--- a/moor_generator/lib/src/model/table.dart
+++ b/moor_generator/lib/src/model/table.dart
@@ -106,7 +106,7 @@ class MoorTable implements MoorSchemaEntity {
   MoorTable({
     this.fromClass,
     this.columns,
-	this.variables,
+	this.variables = const [],
     this.sqlName,
     this.dartTypeName,
     this.primaryKey,

--- a/moor_generator/lib/src/model/variable.dart
+++ b/moor_generator/lib/src/model/variable.dart
@@ -1,0 +1,20 @@
+import 'declarations/declaration.dart';
+
+class MoorVariable implements HasDeclaration 
+{
+	final String type;
+	final String name;
+	final String value;
+
+  	Declaration declaration;
+
+	MoorVariable({
+		this.type,
+		this.name,
+		this.value,
+		this.declaration
+	});
+
+	@override
+	String toString() => '$type $name${value == null ? "" : "= $value"}';
+}

--- a/moor_generator/lib/src/model/variable.dart
+++ b/moor_generator/lib/src/model/variable.dart
@@ -14,7 +14,4 @@ class MoorVariable implements HasDeclaration
 		this.value,
 		this.declaration
 	});
-
-	@override
-	String toString() => '$type $name${value == null ? "" : "= $value"}';
 }

--- a/moor_generator/lib/src/writer/tables/data_class_writer.dart
+++ b/moor_generator/lib/src/writer/tables/data_class_writer.dart
@@ -22,6 +22,10 @@ class DataClassWriter {
           .write('final ${column.dartTypeName} ${column.dartGetterName}; \n');
     }
 
+	for (final variable in table.variables) {
+      _buffer.write('$variable; \n');
+    }
+
     // write constructor with named optional fields
     _buffer
       ..write(table.dartTypeName)

--- a/moor_generator/lib/src/writer/tables/data_class_writer.dart
+++ b/moor_generator/lib/src/writer/tables/data_class_writer.dart
@@ -23,7 +23,8 @@ class DataClassWriter {
     }
 
 	for (final variable in table.variables) {
-      _buffer.write('$variable; \n');
+	  String value = variable.value == null ? "" : "= ${variable.value}";
+      _buffer.write('${variable.type} ${variable.name} $value; \n');
     }
 
     // write constructor with named optional fields


### PR DESCRIPTION
As I was working with this project, I thought it would be interesting to be able to add members to the `DataClass` with a simple annotation `classVariable` (or any better name)

Here is an example below :

```dart
@DataClassName('TodoEntry')
class Todos extends Table {
  IntColumn get id => integer().autoIncrement()();

  TextColumn get content => text()();

  DateTimeColumn get targetDate => dateTime().nullable()();

  IntColumn get category => integer()
      .nullable()
      .customConstraint('NULLABLE REFERENCES categories(id)')();

  @classVariable
  bool withDefaultValue = false;

  @classVariable
  String withoutDefaultValue;
}
```