### PR TITLE
Missing 's' in build.yaml

### DIFF
--- a/docs/content/en/docs/Advanced Features/builder_options.md
+++ b/docs/content/en/docs/Advanced Features/builder_options.md
@@ -69,7 +69,7 @@ targets:
     builders:
       moor_generator:
         options:
-          sqlite_module:
+          sqlite_modules:
             - json1
             - fts5
 ```


### PR DESCRIPTION
In example for sqlite_modules.