### PR TITLE
Expose the underlying sqflite database object

### DIFF
--- a/moor_flutter/CHANGELOG.md
+++ b/moor_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.0
+
+- Expose the underlying database from sqflite in `FlutterQueryExecutor`.
+  This exists only to make migrations to moor easier.
+
 ## 2.0.0
 See the changelog of [moor](https://pub.dev/packages/moor#-changelog-tab-) for details,
 or check out an overview of new features [here](https://moor.simonbinder.eu/v2])

--- a/moor_flutter/lib/moor_flutter.dart
+++ b/moor_flutter/lib/moor_flutter.dart
@@ -189,7 +189,17 @@ class FlutterQueryExecutor extends DelegatedDatabase {
                 singleInstance: singleInstance, creator: creator),
             logStatements: logStatements);
 
-  /// The underlying sqflite [s.Database] object
+  /// The underlying sqflite [s.Database] object used by moor to sent queries.
+  ///
+  /// Using the sqflite database can cause unexpected behavior in moor. For
+  /// instance, stream queries won't update for updates sent to the [s.Database]
+  /// directly.
+  /// For this reason, projects shouldn't use this getter unless they absolutely
+  /// need to. The database is exposed to make migrating from sqflite to moor
+  /// easier.
+  ///
+  /// Note that this returns null until the moor database has been opened.
+  /// A moor database is opened lazily when the first query runs.
   s.Database get sqfliteDb {
     final sqfliteDelegate = delegate as _SqfliteDelegate;
     return sqfliteDelegate.db;

--- a/moor_flutter/lib/moor_flutter.dart
+++ b/moor_flutter/lib/moor_flutter.dart
@@ -188,4 +188,10 @@ class FlutterQueryExecutor extends DelegatedDatabase {
             _SqfliteDelegate(true, path,
                 singleInstance: singleInstance, creator: creator),
             logStatements: logStatements);
+
+  /// The underlying sqflite [s.Database] object
+  s.Database get sqfliteDb {
+    final sqfliteDelegate = delegate as _SqfliteDelegate;
+    return sqfliteDelegate.db;
+  }
 }

--- a/moor_flutter/lib/moor_flutter.dart
+++ b/moor_flutter/lib/moor_flutter.dart
@@ -189,7 +189,7 @@ class FlutterQueryExecutor extends DelegatedDatabase {
                 singleInstance: singleInstance, creator: creator),
             logStatements: logStatements);
 
-  /// The underlying sqflite [s.Database] object used by moor to sent queries.
+  /// The underlying sqflite [s.Database] object used by moor to send queries.
   ///
   /// Using the sqflite database can cause unexpected behavior in moor. For
   /// instance, stream queries won't update for updates sent to the [s.Database]

--- a/moor_flutter/pubspec.yaml
+++ b/moor_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: moor_flutter
 description: Flutter implementation of moor, a safe and reactive persistence library for Dart applications
-version: 2.0.0
+version: 2.1.0
 repository: https://github.com/simolus3/moor
 homepage: https://moor.simonbinder.eu/
 issue_tracker: https://github.com/simolus3/moor/issues


### PR DESCRIPTION
Solves #370 
Any one interested in using the underlying `sqflite` `Database` would only need to add a getter like this to their own `GeneratedDatabase`.

```dart
import 'package:sqflite/sqflite.dart' as sqflite;

class MyDatabase extends _$MyDatabase {
  MyDatabase()
      : super(FlutterQueryExecutor.inDatabaseFolder(path: 'db.sqlite'));

  sqflite.Database get sqfliteDb {
    final flutterQueryExecutor = executor as FlutterQueryExecutor;
    return flutterQueryExecutor.sqfliteDb;
  }
  ...
}
``` 