### PR TITLE
FIX: onUpgrade callback was not being called when downgrading db in moor_flutter

### DIFF
--- a/extras/encryption/lib/encrypted_moor.dart
+++ b/extras/encryption/lib/encrypted_moor.dart
@@ -73,6 +73,9 @@ class _SqfliteDelegate extends DatabaseDelegate with _SqfliteExecutor {
       onUpgrade: (db, from, to) {
         _loadedSchemaVersion = from;
       },
+      onDowngrade: (db, from, to) {
+        _loadedSchemaVersion = from;
+      },
       singleInstance: singleInstance,
     );
   }

--- a/extras/integration_tests/flutter_db/lib/main.dart
+++ b/extras/integration_tests/flutter_db/lib/main.dart
@@ -35,9 +35,19 @@ Future<void> main() async {
 
   // Additional integration test for flutter: Test loading a database from asset
   test('can load a database from asset', () async {
+    const dbNameInDevice = 'app_from_asset.db';
+
+    final folder = await getDatabasesPath();
+    final file = File(join(folder, dbNameInDevice));
+
+    if (await file.exists()) {
+      await file.delete();
+    }
+
+
     var didCallCreator = false;
     final executor = FlutterQueryExecutor.inDatabaseFolder(
-      path: 'app_from_asset.db',
+      path: dbNameInDevice,
       singleInstance: true,
       creator: (file) async {
         final content = await rootBundle.load('test_asset.db');
@@ -46,7 +56,7 @@ Future<void> main() async {
       },
     );
     final database = Database(executor);
-    await database.getUserById(0); // load user so that the db is opened
+    await database.executor.ensureOpen();
 
     expect(didCallCreator, isTrue);
   });

--- a/extras/integration_tests/tests/lib/database/database.dart
+++ b/extras/integration_tests/tests/lib/database/database.dart
@@ -105,7 +105,7 @@ class Database extends _$Database {
         if (details.wasCreated) {
           // make sure that transactions can be used in the beforeOpen callback.
           await transaction(() async {
-            batch((batch) {
+            await batch((batch) {
               batch.insertAll(users, [people.dash, people.duke, people.gopher]);
             });
           });

--- a/extras/integration_tests/tests/lib/database/database.dart
+++ b/extras/integration_tests/tests/lib/database/database.dart
@@ -87,6 +87,12 @@ class Database extends _$Database {
 
   Database(QueryExecutor e, {this.schemaVersion = 2}) : super(e);
 
+  /// It will be set in the onUpgrade callback. Null if no migration ocurred
+  int schemaVersionChangedFrom;
+  
+  /// It will be set in the onUpgrade callback. Null if no migration ocurred
+  int schemaVersionChangedTo;
+
   @override
   MigrationStrategy get migration {
     return MigrationStrategy(
@@ -97,6 +103,9 @@ class Database extends _$Database {
         }
       },
       onUpgrade: (m, from, to) async {
+        schemaVersionChangedFrom = from;
+        schemaVersionChangedTo = to;
+
         if (from == 1) {
           await m.createTable(friendships);
         }

--- a/extras/integration_tests/tests/lib/suite/migrations.dart
+++ b/extras/integration_tests/tests/lib/suite/migrations.dart
@@ -25,6 +25,22 @@ void migrationTests(TestExecutor executor) {
     // the 3 initial users plus People.florian
     final count = await database.userCountQuery().getSingle();
     expect(count, 4);
+    expect(database.schemaVersionChangedFrom, 1);
+    expect(database.schemaVersionChangedTo, 2);
+
+    await database.close();
+  });
+
+  test('runs the migrator when downgrading', () async {
+    var database = Database(executor.createExecutor(), schemaVersion: 2);
+    await database.executor.ensureOpen(); // Create the database
+    await database.close();
+
+    database = Database(executor.createExecutor(), schemaVersion: 1);
+    await database.executor.ensureOpen(); // Let the migrator run
+    
+    expect(database.schemaVersionChangedFrom, 2);
+    expect(database.schemaVersionChangedTo, 1);
 
     await database.close();
   });

--- a/moor/lib/src/runtime/query_builder/migration.dart
+++ b/moor/lib/src/runtime/query_builder/migration.dart
@@ -3,7 +3,10 @@ part of 'query_builder.dart';
 /// Signature of a function that will be invoked when a database is created.
 typedef OnCreate = Future<void> Function(Migrator m);
 
-/// Signature of a function that will be invoked when a database is upgraded.
+/// Signature of a function that will be invoked when a database is upgraded
+/// or downgraded.
+/// In version upgrades: from < to
+/// In version downgrades: from > to
 typedef OnUpgrade = Future<void> Function(Migrator m, int from, int to);
 
 /// Signature of a function that's called before a database is marked opened by
@@ -24,7 +27,8 @@ class MigrationStrategy {
   final OnCreate onCreate;
 
   /// Executes when the database has been opened previously, but the last access
-  /// happened at a lower [GeneratedDatabase.schemaVersion].
+  /// happened at a different [GeneratedDatabase.schemaVersion].
+  /// Schema version upgrades and downgrades will both be run here.
   final OnUpgrade onUpgrade;
 
   /// Executes after the database is ready to be used (ie. it has been opened

--- a/moor_flutter/lib/moor_flutter.dart
+++ b/moor_flutter/lib/moor_flutter.dart
@@ -73,6 +73,9 @@ class _SqfliteDelegate extends DatabaseDelegate with _SqfliteExecutor {
       onUpgrade: (db, from, to) {
         _loadedSchemaVersion = from;
       },
+      onDowngrade: (db, from, to) {
+        _loadedSchemaVersion = from;
+      },
       singleInstance: singleInstance,
     );
   }


### PR DESCRIPTION
PR splitted in 2 commits. The first one improves a bit the integrations tests with moor_flutter, I was having issues with those changes otherwise.

As the title says, the onUpgrade callback was not being called because sqflite distinguishes between onUpgrade and onDowngrade, so if we are trying to use a db version lower than the version installed, onUpgrade would not fire. That is sometimes undesired if we want to do some checks or custom logic with different db versions. For example trying to import an arbitrary db (with any of the versions supported by the app) into the app with a file picker. 