### PR TITLE
Remove sqflite_sqlcipher git dependency

### DIFF
--- a/docs/content/en/docs/Other engines/encryption.md
+++ b/docs/content/en/docs/Other engines/encryption.md
@@ -3,18 +3,10 @@ title: Encryption
 description: Use moor on encrypted databases
 ---
 
-{{% alert title="Security notice" color="warning" %}}
-> This feature uses an external library for all the encryption work. Importing
-that library as described here would always pull the latest version from git
-when running `pub upgrade`. If you want to be sure that you're using a safe version
-that you can trust, consider pulling `sqflite_sqlcipher` and `encrypted_moor` once
-and then include your local version via a path in the pubspec.
-{{% /alert %}}
-
 Starting from 1.7, we have a version of moor that can work with encrypted databases by using the
-[sqflite_sqlcipher](https://github.com/davidmartos96/sqflite_sqlcipher) library
+[sqflite_sqlcipher](https://pub.dev/packages/sqflite_sqlcipher) library
 by [@davidmartos96](https://github.com/davidmartos96). To use it, you need to
-remove the dependency on `moor_flutter` from your `pubspec.yaml` and replace it
+remove the dependency on `moor_flutter` and `moor_ffi` from your `pubspec.yaml` and replace it
 with this:
 ```yaml
 dependencies:
@@ -29,3 +21,9 @@ Instead of importing `package:moor_flutter/moor_flutter` in your apps, you would
 both `package:moor/moor.dart` and `package:encrypted_moor/encrypted_moor.dart`.
 
 Finally, you can replace `FlutterQueryExecutor` with an `EncryptedExecutor`.
+
+## Extra setup on Android and iOS
+
+Some extra steps may have to be taken in your project so that SQLCipher works correctly. For example, the ProGuard configuration on Android for apps built for release.
+
+[Read instructions](https://pub.dev/packages/sqflite_sqlcipher) (Usage and instrallation instructions of the package can be ignored, as that is handled internally by `moor`)

--- a/extras/encryption/lib/encrypted_moor.dart
+++ b/extras/encryption/lib/encrypted_moor.dart
@@ -10,7 +10,7 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart';
 import 'package:moor/moor.dart';
 import 'package:moor/backends.dart';
-import 'package:sqflite/sqflite.dart' as s;
+import 'package:sqflite_sqlcipher/sqflite.dart' as s;
 
 /// Signature of a function that runs when a database doesn't exist on file.
 /// This can be useful to, for instance, load the database from an asset if it

--- a/extras/encryption/pubspec.yaml
+++ b/extras/encryption/pubspec.yaml
@@ -8,10 +8,7 @@ environment:
 
 dependencies:
   moor: ^2.0.0
-  sqflite:
-    git:
-      url: https://www.github.com/davidmartos96/sqflite_sqlcipher.git
-      path: sqflite
+  sqflite_sqlcipher: ^1.0.0+3
 
 dependency_overrides:
   moor:


### PR DESCRIPTION
I've made a pub package for the SQLCipher plugin, so the git dependency is not needed anymore. The reference for the plugin is in the branch `publish` in the repository https://github.com/davidmartos96/sqflite_sqlcipher