### PR TITLE
Fix weird behaviour with nested results

### DIFF
--- a/moor_generator/lib/src/writer/queries/query_writer.dart
+++ b/moor_generator/lib/src/writer/queries/query_writer.dart
@@ -440,7 +440,7 @@ class QueryWriter {
           }
 
           final columnName = column.name.name;
-          expanded.write('"$table.$columnName" AS "$prefix.$columnName"');
+          expanded.write('"$table"."$columnName" AS "$prefix.$columnName"');
         }
 
         replaceNode(rewriteTarget, expanded.toString());


### PR DESCRIPTION
I have a query like this:
```
listCampaign:
SELECT
    campaign.**,
    prosperity.**,
    (prosperity_tick.id - prosperity_min_tick.id) AS prosperity_value,
    (prosperity_max_tick.id - prosperity_min_tick.id) AS prosperity_max_value
FROM campaign
INNER JOIN prosperity_tick
    ON prosperity_tick.id = campaign.prosperity_tick_id
INNER JOIN prosperity
    ON prosperity.id = prosperity_tick.prosperity_id
INNER JOIN (
    SELECT MAX(prosperity_tick.id) AS id, prosperity_tick.prosperity_id
    FROM prosperity_tick
    GROUP BY prosperity_tick.prosperity_id
) AS prosperity_max_tick
    ON prosperity_max_tick.prosperity_id = prosperity.id
INNER JOIN (
    SELECT MIN(prosperity_tick.id) AS id, prosperity_tick.prosperity_id
    FROM prosperity_tick
    GROUP BY prosperity_tick.prosperity_id
) AS prosperity_min_tick
    ON prosperity_min_tick.prosperity_id = prosperity.id
ORDER BY campaign.name;
```
and for some reason this causes the quoted columns to act like strings instead of columns.

I get this error from moor:
`flutter: type 'String' is not a subtype of type 'int' in type cast`

At first I thought it was assigning the wrong columns but when I added:
```
          if (snapshot.hasError) {
            print(snapshot.error);
            // copied form database.g.dart
            final rows = AppDb.of(context).customSelect(
                'SELECT\n    "campaign.id" AS "nested_0.id", "campaign.name" AS "nested_0.name", "campaign.prosperity_tick_id" AS "nested_0.prosperity_tick_id", "campaign.donation_tick_id" AS "nested_0.donation_tick_id",\n    "prosperity.id" AS "nested_1.id", "prosperity.name" AS "nested_1.name", "prosperity.level_id" AS "nested_1.level_id", "prosperity.unlock_item_group_id" AS "nested_1.unlock_item_group_id",\n    (prosperity_tick.id - prosperity_min_tick.id) AS prosperity_value,\n    (prosperity_max_tick.id - prosperity_min_tick.id) AS prosperity_max_value\nFROM campaign\nINNER JOIN prosperity_tick\n    ON prosperity_tick.id = campaign.prosperity_tick_id\nINNER JOIN prosperity\n    ON prosperity.id = prosperity_tick.prosperity_id\nINNER JOIN (\n    SELECT MAX(prosperity_tick.id) AS id, prosperity_tick.prosperity_id\n    FROM prosperity_tick\n    GROUP BY prosperity_tick.prosperity_id\n) AS prosperity_max_tick\n    ON prosperity_max_tick.prosperity_id = prosperity.id\nINNER JOIN (\n    SELECT MIN(prosperity_tick.id) AS id, prosperity_tick.prosperity_id\n    FROM prosperity_tick\n    GROUP BY prosperity_tick.prosperity_id\n) AS prosperity_min_tick\n    ON prosperity_min_tick.prosperity_id = prosperity.id\nORDER BY campaign.name',
                variables: [],
                readsFrom: {}).get();
            rows.then((value) {
              value.forEach((row) {
                row.data.entries.forEach((field) {
                  print('${field.key}: ${field.value}');
                });
              });
            });
          }
```

I got:
```
flutter: nested_0.id: campaign.id
flutter: nested_0.name: campaign.name
flutter: nested_0.prosperity_tick_id: campaign.prosperity_tick_id
flutter: nested_0.donation_tick_id: campaign.donation_tick_id
flutter: nested_1.id: prosperity.id
flutter: nested_1.name: prosperity.name
flutter: nested_1.level_id: prosperity.level_id
flutter: nested_1.unlock_item_group_id: prosperity.unlock_item_group_id
flutter: prosperity_value: 0
flutter: prosperity_max_value: 4
```

Which is super weird, it looks like it's using the column name as the value. All other uses of ** worked as expected but this one doesn't (I tried deleting the db and creating a new one but same issue). It must be something to do with the last 2 columns.

After my fix:
```
flutter: nested_0.id: 6da2ec3c-ec04-43e2-9e5b-c11d36acb42b
flutter: nested_0.name: Test
flutter: nested_0.prosperity_tick_id: 1
flutter: nested_0.donation_tick_id: 0
flutter: nested_1.id: 1
flutter: nested_1.name: Prosperity 1
flutter: nested_1.level_id: 1
flutter: nested_1.unlock_item_group_id: gloomhaven_prosperity_01
flutter: prosperity_value: 0
flutter: prosperity_max_value: 4
```