### PR TITLE
doc: update example to include missing imports

### DIFF
--- a/docs/content/en/docs/Getting started/_index.md
+++ b/docs/content/en/docs/Getting started/_index.md
@@ -92,6 +92,8 @@ follows:
 import 'package:moor_ffi/moor_ffi.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
+import 'package:moor/moor.dart';
+import 'dart:io';
 
 LazyDatabase _openConnection() {
   // the LazyDatabase util lets us find the right location for the file async.


### PR DESCRIPTION
`dart:io` is necessary for `File`
`moor.dart` is necessary for `LazyDatabase`

Thanks for the library 👍 