### PR TITLE
[moor_ffi] Add readOnly support to Database.open 

### DIFF
--- a/moor_ffi/lib/src/impl/database.dart
+++ b/moor_ffi/lib/src/impl/database.dart
@@ -34,7 +34,7 @@ class Database {
 
   /// Opens an sqlite3 database from a filename.
   ///
-  /// Unless [readOnly] is set to true, database is open in read/write mode.
+  /// Unless [readOnly] is set to true, database is opened in read/write mode.
   factory Database.open(String fileName, {bool readOnly = false}) {
     final dbOut = allocate<Pointer<types.Database>>();
     final pathC = CBlob.allocateString(fileName);

--- a/moor_ffi/lib/src/impl/database.dart
+++ b/moor_ffi/lib/src/impl/database.dart
@@ -15,6 +15,7 @@ part 'errors.dart';
 part 'prepared_statement.dart';
 
 const _openingFlags = Flags.SQLITE_OPEN_READWRITE | Flags.SQLITE_OPEN_CREATE;
+const _readOnlyOpeningFlags = Flags.SQLITE_OPEN_READONLY;
 
 /// A opened sqlite database.
 class Database {
@@ -32,12 +33,16 @@ class Database {
   factory Database.memory() => Database.open(':memory:');
 
   /// Opens an sqlite3 database from a filename.
-  factory Database.open(String fileName) {
+  ///
+  /// Unless [readOnly] is set to true, database is open in read/write mode.
+  factory Database.open(String fileName, {bool readOnly = false}) {
     final dbOut = allocate<Pointer<types.Database>>();
     final pathC = CBlob.allocateString(fileName);
+    final openingFlags =
+        (readOnly ?? false) ? _readOnlyOpeningFlags : _openingFlags;
 
     final resultCode =
-        bindings.sqlite3_open_v2(pathC, dbOut, _openingFlags, nullPtr());
+        bindings.sqlite3_open_v2(pathC, dbOut, openingFlags, nullPtr());
     final dbPointer = dbOut.value;
 
     dbOut.free();

--- a/moor_ffi/test/database/database_test.dart
+++ b/moor_ffi/test/database/database_test.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:moor_ffi/database.dart';
+import 'package:path/path.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -17,5 +20,41 @@ void main() {
 
     db.close();
     db.close(); // shouldn't throw or crash
+  });
+
+  test('open read-only', () async {
+    final path = join('.dart_tool', 'moor_ffi', 'test', 'read_only.db');
+    // Make sure the path exists
+    try {
+      await Directory(dirname(path)).create(recursive: true);
+    } catch (_) {}
+    // but not the db
+    try {
+      await File(path).delete();
+    } catch (_) {}
+
+    // Opening a non-existent database should fail
+    try {
+      Database.open(path, readOnly: true);
+      fail('should fail');
+    } on SqliteException catch (_) {}
+
+    // Open in read-write mode to create the database
+    var db = Database.open(path);
+    // Change the user version to test read-write access
+    db.setUserVersion(1);
+    db.close();
+
+    // Open in read-only
+    db = Database.open(path, readOnly: true);
+    // Change the user version to test read-only mode
+    try {
+      db.setUserVersion(2);
+      fail('should fail');
+    } on SqliteException catch (_) {}
+    // Check that it has not changed
+    expect(db.userVersion(), 1);
+
+    db.close();
   });
 }


### PR DESCRIPTION
This is in response to the following issue: https://github.com/simolus3/moor/issues/510

I choose an opinionated readOnly flag for Database.open but you can decide to change that. I have not added the flag to openFile. Let me know if you want it too.

I added a small unit test too.