### PR TITLE
[moor_ffi] Add primary and extended result (error) code to SqliteException

### DIFF
--- a/moor_ffi/lib/src/bindings/bindings.dart
+++ b/moor_ffi/lib/src/bindings/bindings.dart
@@ -69,6 +69,8 @@ class _SQLiteBindings {
 
   Pointer<CBlob> Function(int code) sqlite3_errstr;
   Pointer<CBlob> Function(Pointer<Database> database) sqlite3_errmsg;
+  int Function(Pointer<Database> database, int onOff)
+      sqlite3_extended_result_codes;
 
   int Function(Pointer<Statement> statement, int columnIndex, double value)
       sqlite3_bind_double;
@@ -144,6 +146,10 @@ class _SQLiteBindings {
         .asFunction();
     sqlite3_errmsg = sqlite
         .lookup<NativeFunction<sqlite3_errmsg_native_t>>('sqlite3_errmsg')
+        .asFunction();
+    sqlite3_extended_result_codes = sqlite
+        .lookup<NativeFunction<sqlite3_extended_result_codes_t>>(
+            'sqlite3_extended_result_codes')
         .asFunction();
     sqlite3_column_count = sqlite
         .lookup<NativeFunction<sqlite3_column_count_native_t>>(

--- a/moor_ffi/lib/src/bindings/signatures.dart
+++ b/moor_ffi/lib/src/bindings/signatures.dart
@@ -41,6 +41,9 @@ typedef sqlite3_errstr_native_t = Pointer<CBlob> Function(Int32 error);
 typedef sqlite3_errmsg_native_t = Pointer<CBlob> Function(
     Pointer<Database> database);
 
+typedef sqlite3_extended_result_codes_t = Int32 Function(
+    Pointer<Database> database, Int32 onOff);
+
 typedef sqlite3_column_count_native_t = Int32 Function(
     Pointer<Statement> statement);
 

--- a/moor_ffi/lib/src/impl/database.dart
+++ b/moor_ffi/lib/src/impl/database.dart
@@ -49,6 +49,9 @@ class Database {
     pathC.free();
 
     if (resultCode == Errors.SQLITE_OK) {
+      // Turn extended result code to on.
+      bindings.sqlite3_extended_result_codes(dbPointer, 1);
+
       return Database._(dbPointer);
     } else {
       bindings.sqlite3_close_v2(dbPointer);
@@ -104,7 +107,6 @@ class Database {
 
     final result =
         bindings.sqlite3_exec(_db, sqlPtr, nullPtr(), nullPtr(), errorOut);
-
     sqlPtr.free();
 
     final errorPtr = errorOut.value;
@@ -118,7 +120,7 @@ class Database {
     }
 
     if (result != Errors.SQLITE_OK) {
-      throw SqliteException(errorMsg);
+      throw SqliteException(result, errorMsg);
     }
   }
 

--- a/moor_ffi/lib/src/impl/errors.dart
+++ b/moor_ffi/lib/src/impl/errors.dart
@@ -4,10 +4,21 @@ class SqliteException implements Exception {
   final String message;
   final String explanation;
 
-  SqliteException(this.message, [this.explanation]);
+  /// SQLite extended result code.
+  ///
+  /// As defined in https://sqlite.org/rescode.html, it represent an error code,
+  /// providing some idea of the cause of the failure.
+  final int extendedResultCode;
 
-  factory SqliteException._fromErrorCode(Pointer<types.Database> db,
-      [int code]) {
+  /// SQLite primary result code.
+  ///
+  /// As defined in https://sqlite.org/rescode.html, it represent an error code,
+  /// providing some idea of the cause of the failure.
+  int get resultCode => extendedResultCode & 0xFF;
+
+  SqliteException(this.extendedResultCode, this.message, [this.explanation]);
+
+  factory SqliteException._fromErrorCode(Pointer<types.Database> db, int code) {
     // We don't need to free the pointer returned by sqlite3_errmsg: "Memory to
     // hold the error message string is managed internally. The application does
     // not need to worry about freeing the result."
@@ -19,15 +30,15 @@ class SqliteException implements Exception {
       explanation = bindings.sqlite3_errstr(code).readString();
     }
 
-    return SqliteException(dbMessage, explanation);
+    return SqliteException(code, dbMessage, explanation);
   }
 
   @override
   String toString() {
     if (explanation == null) {
-      return 'SqliteException: $message';
+      return 'SqliteException($extendedResultCode): $message';
     } else {
-      return 'SqliteException: $message, $explanation';
+      return 'SqliteException($extendedResultCode): $message, $explanation';
     }
   }
 }

--- a/moor_ffi/test/database/sqlite_exception_test.dart
+++ b/moor_ffi/test/database/sqlite_exception_test.dart
@@ -1,0 +1,125 @@
+import 'dart:io';
+
+import 'package:moor_ffi/database.dart';
+import 'package:moor_ffi/src/bindings/constants.dart';
+import 'package:path/path.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('open read-only exception', () async {
+    final path =
+        join('.dart_tool', 'moor_ffi', 'test', 'read_only_exception.db');
+    // Make sure the path exists
+    try {
+      await Directory(dirname(path)).create(recursive: true);
+    } catch (_) {}
+    // but not the db
+    try {
+      await File(path).delete();
+    } catch (_) {}
+
+    // Opening a non-existent database should fail
+    try {
+      Database.open(path, readOnly: true);
+      fail('should fail');
+    } on SqliteException catch (e) {
+      expect(e.extendedResultCode, Errors.SQLITE_CANTOPEN);
+      expect(e.toString(), startsWith('SqliteException(14): '));
+    }
+  });
+
+  test('statement exception', () async {
+    // Only testing some common errors...
+    final db = Database.memory();
+
+    // Basic syntax error
+    try {
+      db.execute('DUMMY');
+      fail('should fail');
+    } on SqliteException catch (e) {
+      expect(e.extendedResultCode, Errors.SQLITE_ERROR);
+      expect(e.resultCode, Errors.SQLITE_ERROR);
+      expect(e.toString(), startsWith('SqliteException(1): '));
+    }
+
+    // No table
+    try {
+      db.execute('SELECT * FROM missing_table');
+      fail('should fail');
+    } on SqliteException catch (e) {
+      expect(e.extendedResultCode, Errors.SQLITE_ERROR);
+      expect(e.resultCode, Errors.SQLITE_ERROR);
+    }
+
+    // Constraint primary key
+    db.execute('CREATE TABLE Test (name TEXT PRIMARY KEY)');
+    db.execute("INSERT INTO Test(name) VALUES('test1')");
+    try {
+      db.execute("INSERT INTO Test(name) VALUES('test1')");
+      fail('should fail');
+    } on SqliteException catch (e) {
+      // SQLITE_CONSTRAINT_PRIMARYKEY (1555)
+      expect(e.extendedResultCode, 1555);
+      expect(e.resultCode, Errors.SQLITE_CONSTRAINT);
+      expect(e.toString(), startsWith('SqliteException(1555): '));
+    }
+
+    // Constraint using prepared statement
+    db.execute('CREATE TABLE Test2 (id PRIMARY KEY, name TEXT UNIQUE)');
+    final prepared = db.prepare('INSERT INTO Test2(name) VALUES(?)');
+    prepared.execute(['test2']);
+    try {
+      prepared.execute(['test2']);
+      fail('should fail');
+    } on SqliteException catch (e) {
+      // SQLITE_CONSTRAINT_UNIQUE (2067)
+      expect(e.extendedResultCode, 2067);
+      expect(e.resultCode, Errors.SQLITE_CONSTRAINT);
+    }
+    db.close();
+  });
+
+  test('busy exception', () async {
+    final path = join('.dart_tool', 'moor_ffi', 'test', 'busy.db');
+    // Make sure the path exists
+    try {
+      await Directory(dirname(path)).create(recursive: true);
+    } catch (_) {}
+    // but not the db
+    try {
+      await File(path).delete();
+    } catch (_) {}
+
+    final db1 = Database.open(path);
+    final db2 = Database.open(path);
+    db1.execute('BEGIN EXCLUSIVE TRANSACTION');
+    try {
+      db2.execute('BEGIN EXCLUSIVE TRANSACTION');
+      fail('should fail');
+    } on SqliteException catch (e) {
+      expect(e.extendedResultCode, Errors.SQLITE_BUSY);
+      expect(e.resultCode, Errors.SQLITE_BUSY);
+    }
+    db1.close();
+    db2.close();
+  });
+
+  test('invalid format', () async {
+    final path = join('.dart_tool', 'moor_ffi', 'test', 'invalid_format.db');
+    // Make sure the path exists
+    try {
+      await Directory(dirname(path)).create(recursive: true);
+    } catch (_) {}
+    await File(path).writeAsString('not a database file');
+
+    final db = Database.open(path);
+    try {
+      db.setUserVersion(1);
+      fail('should fail');
+    } on SqliteException catch (e) {
+      expect(e.extendedResultCode, Errors.SQLITE_NOTADB);
+      expect(e.resultCode, Errors.SQLITE_NOTADB);
+    }
+    db.close();
+  }, solo: true);
+}

--- a/moor_ffi/test/database/sqlite_exception_test.dart
+++ b/moor_ffi/test/database/sqlite_exception_test.dart
@@ -121,5 +121,5 @@ void main() {
       expect(e.resultCode, Errors.SQLITE_NOTADB);
     }
     db.close();
-  }, solo: true);
+  });
 }


### PR DESCRIPTION
This a PR in response to the following feature request: https://github.com/simolus3/moor/issues/509

It forces the database to return extended result code and add resultCode (primary) and extendedResultCode to SqliteException.

Unit tests have been added to test some common errors