### PR TITLE
Fix/min analyzer version missmatch

### DIFF
--- a/moor_generator/CHANGELOG.md
+++ b/moor_generator/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.2.0
 
 - Support custom result class names for queries.
+- Fix minimum `analyzer: ^0.39.5` version requirement
 
 ## 3.1.0
 

--- a/moor_generator/pubspec.yaml
+++ b/moor_generator/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   sqlparser: ^0.9.0
 
   # Dart analysis
-  analyzer: '^0.39.0'
+  analyzer: '^0.39.5'
   analyzer_plugin_fork: ^0.2.2 # todo switch back to analyzer_plugin when it supports analyzer 0.39.0
   source_span: ^1.5.5
 


### PR DESCRIPTION
`languageVersionMajor/Minor` was added in analyzer version 0.39.5 and is used since 4d463dd1453ad9f205df286688d1e6dba906d65e
