### PR TITLE
Add toString to companions

### DIFF
--- a/moor/example/example.g.dart
+++ b/moor/example/example.g.dart
@@ -127,6 +127,15 @@ class CategoriesCompanion extends UpdateCompanion<Category> {
     }
     return map;
   }
+
+  @override
+  String toString() {
+    return (StringBuffer('CategoriesCompanion(')
+          ..write('id: $id, ')
+          ..write('description: $description')
+          ..write(')'))
+        .toString();
+  }
 }
 
 class $CategoriesTable extends Categories
@@ -370,6 +379,17 @@ class RecipesCompanion extends UpdateCompanion<Recipe> {
       map['category'] = Variable<int>(category.value);
     }
     return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('RecipesCompanion(')
+          ..write('id: $id, ')
+          ..write('title: $title, ')
+          ..write('instructions: $instructions, ')
+          ..write('category: $category')
+          ..write(')'))
+        .toString();
   }
 }
 
@@ -615,6 +635,16 @@ class IngredientsCompanion extends UpdateCompanion<Ingredient> {
     }
     return map;
   }
+
+  @override
+  String toString() {
+    return (StringBuffer('IngredientsCompanion(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('caloriesPer100g: $caloriesPer100g')
+          ..write(')'))
+        .toString();
+  }
 }
 
 class $IngredientsTable extends Ingredients
@@ -857,6 +887,16 @@ class IngredientInRecipesCompanion extends UpdateCompanion<IngredientInRecipe> {
       map['amount'] = Variable<int>(amountInGrams.value);
     }
     return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('IngredientInRecipesCompanion(')
+          ..write('recipe: $recipe, ')
+          ..write('ingredient: $ingredient, ')
+          ..write('amountInGrams: $amountInGrams')
+          ..write(')'))
+        .toString();
   }
 }
 

--- a/moor/lib/src/runtime/data_class.dart
+++ b/moor/lib/src/runtime/data_class.dart
@@ -122,6 +122,9 @@ class Value<T> {
   const Value.absent()
       : value = null,
         present = false;
+
+  @override
+  String toString() => present ? 'Value($value)' : 'Value.absent()';
 }
 
 /// Serializer responsible for mapping atomic types from and to json.

--- a/moor/test/data/tables/custom_tables.g.dart
+++ b/moor/test/data/tables/custom_tables.g.dart
@@ -199,6 +199,17 @@ class ConfigCompanion extends UpdateCompanion<Config> {
     }
     return map;
   }
+
+  @override
+  String toString() {
+    return (StringBuffer('ConfigCompanion(')
+          ..write('configKey: $configKey, ')
+          ..write('configValue: $configValue, ')
+          ..write('syncState: $syncState, ')
+          ..write('syncStateImplicit: $syncStateImplicit')
+          ..write(')'))
+        .toString();
+  }
 }
 
 class ConfigTable extends Table with TableInfo<ConfigTable, Config> {
@@ -407,6 +418,15 @@ class WithDefaultsCompanion extends UpdateCompanion<WithDefault> {
     }
     return map;
   }
+
+  @override
+  String toString() {
+    return (StringBuffer('WithDefaultsCompanion(')
+          ..write('a: $a, ')
+          ..write('b: $b')
+          ..write(')'))
+        .toString();
+  }
 }
 
 class WithDefaults extends Table with TableInfo<WithDefaults, WithDefault> {
@@ -563,6 +583,14 @@ class NoIdsCompanion extends UpdateCompanion<NoId> {
       map['payload'] = Variable<Uint8List>(payload.value);
     }
     return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('NoIdsCompanion(')
+          ..write('payload: $payload')
+          ..write(')'))
+        .toString();
   }
 }
 
@@ -758,6 +786,16 @@ class WithConstraintsCompanion extends UpdateCompanion<WithConstraint> {
       map['c'] = Variable<double>(c.value);
     }
     return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('WithConstraintsCompanion(')
+          ..write('a: $a, ')
+          ..write('b: $b, ')
+          ..write('c: $c')
+          ..write(')'))
+        .toString();
   }
 }
 
@@ -1012,6 +1050,17 @@ class MytableCompanion extends UpdateCompanion<MytableData> {
     }
     return map;
   }
+
+  @override
+  String toString() {
+    return (StringBuffer('MytableCompanion(')
+          ..write('someid: $someid, ')
+          ..write('sometext: $sometext, ')
+          ..write('somebool: $somebool, ')
+          ..write('somedate: $somedate')
+          ..write(')'))
+        .toString();
+  }
 }
 
 class Mytable extends Table with TableInfo<Mytable, MytableData> {
@@ -1241,6 +1290,16 @@ class EmailCompanion extends UpdateCompanion<EMail> {
       map['body'] = Variable<String>(body.value);
     }
     return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('EmailCompanion(')
+          ..write('sender: $sender, ')
+          ..write('title: $title, ')
+          ..write('body: $body')
+          ..write(')'))
+        .toString();
   }
 }
 

--- a/moor/test/data/tables/todos.g.dart
+++ b/moor/test/data/tables/todos.g.dart
@@ -217,6 +217,18 @@ class TodosTableCompanion extends UpdateCompanion<TodoEntry> {
     }
     return map;
   }
+
+  @override
+  String toString() {
+    return (StringBuffer('TodosTableCompanion(')
+          ..write('id: $id, ')
+          ..write('title: $title, ')
+          ..write('content: $content, ')
+          ..write('targetDate: $targetDate, ')
+          ..write('category: $category')
+          ..write(')'))
+        .toString();
+  }
 }
 
 class $TodosTableTable extends TodosTable
@@ -483,6 +495,16 @@ class CategoriesCompanion extends UpdateCompanion<Category> {
       map['priority'] = Variable<int>(converter.mapToSql(priority.value));
     }
     return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CategoriesCompanion(')
+          ..write('id: $id, ')
+          ..write('description: $description, ')
+          ..write('priority: $priority')
+          ..write(')'))
+        .toString();
   }
 }
 
@@ -773,6 +795,18 @@ class UsersCompanion extends UpdateCompanion<User> {
     }
     return map;
   }
+
+  @override
+  String toString() {
+    return (StringBuffer('UsersCompanion(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('isAwesome: $isAwesome, ')
+          ..write('profilePicture: $profilePicture, ')
+          ..write('creationTime: $creationTime')
+          ..write(')'))
+        .toString();
+  }
 }
 
 class $UsersTable extends Users with TableInfo<$UsersTable, User> {
@@ -1005,6 +1039,15 @@ class SharedTodosCompanion extends UpdateCompanion<SharedTodo> {
       map['user'] = Variable<int>(user.value);
     }
     return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('SharedTodosCompanion(')
+          ..write('todo: $todo, ')
+          ..write('user: $user')
+          ..write(')'))
+        .toString();
   }
 }
 
@@ -1239,6 +1282,16 @@ class TableWithoutPKCompanion extends UpdateCompanion<TableWithoutPKData> {
     }
     return map;
   }
+
+  @override
+  String toString() {
+    return (StringBuffer('TableWithoutPKCompanion(')
+          ..write('notReallyAnId: $notReallyAnId, ')
+          ..write('someFloat: $someFloat, ')
+          ..write('custom: $custom')
+          ..write(')'))
+        .toString();
+  }
 }
 
 class $TableWithoutPKTable extends TableWithoutPK
@@ -1446,6 +1499,15 @@ class PureDefaultsCompanion extends UpdateCompanion<PureDefault> {
       map['insert'] = Variable<String>(txt.value);
     }
     return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PureDefaultsCompanion(')
+          ..write('id: $id, ')
+          ..write('txt: $txt')
+          ..write(')'))
+        .toString();
   }
 }
 

--- a/moor_generator/lib/src/writer/tables/update_companion_writer.dart
+++ b/moor_generator/lib/src/writer/tables/update_companion_writer.dart
@@ -23,6 +23,7 @@ class UpdateCompanionWriter {
 
     _writeCopyWith();
     _writeToColumnsOverride();
+    _writeToString();
 
     _buffer.write('}\n');
   }
@@ -178,5 +179,34 @@ class UpdateCompanionWriter {
     }
 
     _buffer.write('return map; \n}\n');
+  }
+
+  void _writeToString() {
+    /*
+      @override
+      String toString() {
+        return (StringBuffer('Category(')
+              ..write('id: $id, ')
+              ..write('description: $description')
+              ..write(')'))
+            .toString();
+     */
+
+    _buffer
+      ..write('@override\nString toString() {\n')
+      ..write('return (StringBuffer('
+          "'${table.getNameForCompanionClass(scope.options)}(')");
+
+    for (var i = 0; i < table.columns.length; i++) {
+      final column = table.columns[i];
+      final dartGetterName = column.dartGetterName;
+
+      _buffer.write("..write('$dartGetterName: \$$dartGetterName");
+      if (i != table.columns.length - 1) _buffer.write(', ');
+
+      _buffer.write("')");
+    }
+
+    _buffer..write("..write(')')).toString();")..write('\}\n');
   }
 }


### PR DESCRIPTION
This is very useful for unit tests and debugging, because we can see 
directly what values a companion has.

For example in this error message it is difficult to know which fields 
are set incorrectly:
```
ERROR: No matching calls. All calls: MockTestsDao.upsert(Instance of 'TestsCompanion')
```

With `toString` the error message is easier to read:
```
ERROR: No matching calls. All calls: MockTestsDao.upsert(TestsCompanion(id: Value.absent(), testValue: Value(5)))
```