### PR TITLE
Add hashcode and equals to value

### DIFF
--- a/moor/lib/src/runtime/data_class.dart
+++ b/moor/lib/src/runtime/data_class.dart
@@ -125,6 +125,17 @@ class Value<T> {
 
   @override
   String toString() => present ? 'Value($value)' : 'Value.absent()';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Value &&
+          runtimeType == other.runtimeType &&
+          present == other.present &&
+          value == other.value;
+
+  @override
+  int get hashCode => present.hashCode ^ value.hashCode;
 }
 
 /// Serializer responsible for mapping atomic types from and to json.

--- a/moor/lib/src/runtime/data_class.dart
+++ b/moor/lib/src/runtime/data_class.dart
@@ -129,10 +129,7 @@ class Value<T> {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is Value &&
-          runtimeType == other.runtimeType &&
-          present == other.present &&
-          value == other.value;
+      other is Value && present == other.present && value == other.value;
 
   @override
   int get hashCode => present.hashCode ^ value.hashCode;

--- a/moor/test/data_class_test.dart
+++ b/moor/test/data_class_test.dart
@@ -107,8 +107,38 @@ void main() {
     expect(first.hashCode, equalToFirst.hashCode);
     expect(first, equals(equalToFirst));
 
+    expect(first.hashCode, isNot(equals(different.hashCode)));
     expect(first, isNot(equals(different)));
-    expect(first, equals(first));
+  });
+
+  group('value: hash and ==:', () {
+    test('equal when values are same', () {
+      const first = Value(0);
+      const equalToFirst = Value(0);
+      const different = Value(1);
+
+      expect(first.hashCode, equalToFirst.hashCode);
+      expect(first, equals(equalToFirst));
+
+      expect(first.hashCode, isNot(equals(different.hashCode)));
+      expect(first, isNot(equals(different)));
+    });
+
+    test('equal when value is absent and generic is different', () {
+      const first = Value<int>.absent();
+      const equalToFirst = Value<String>.absent();
+
+      expect(first.hashCode, equalToFirst.hashCode);
+      expect(first, equals(equalToFirst));
+    });
+
+    test('equal when value is null and generic is different', () {
+      const first = Value<int>(null);
+      const equalToFirst = Value<String>(null);
+
+      expect(first.hashCode, equals(equalToFirst.hashCode));
+      expect(first, equals(equalToFirst));
+    });
   });
 }
 

--- a/moor/test/data_class_test.dart
+++ b/moor/test/data_class_test.dart
@@ -139,6 +139,14 @@ void main() {
       expect(first.hashCode, equals(equalToFirst.hashCode));
       expect(first, equals(equalToFirst));
     });
+
+    test("don't equal when one value is absent and the other one is null", () {
+      const first = Value.absent();
+      const different = Value(null);
+
+      expect(first.hashCode, isNot(equals(different.hashCode)));
+      expect(first, isNot(equals(different)));
+    });
   });
 }
 


### PR DESCRIPTION
This simplifies testing, as one can compare Values like this:
```dart
expect(Value(1), Value(1));
```
Or a realistic example:
```dart
final capturedArgument = verify(fooDao.insert(captureAny)).captured.first.createdAt;
expect(capturedArgument, Value(DateTime(0)));
```

A test is still missing which would look something like this:
```dart
test('value support hash and equals', () {
  const first = Value(0);
  final equalToFirst = Value(0);
  const different = Value.absent();

  expect(first.hashCode, equalToFirst.hashCode);
  expect(first, equals(equalToFirst));

  expect(first, isNot(equals(different)));
  expect(first, equals(first));
});
```
I'm not sure where the test is supposed to be.