### PR TITLE
Sqlparser: Allow Backticks(`) for escaping identifiers

### DIFF
--- a/sqlparser/lib/src/reader/tokenizer/scanner.dart
+++ b/sqlparser/lib/src/reader/tokenizer/scanner.dart
@@ -183,13 +183,13 @@ class Scanner {
         _string();
         break;
       case $double_quote:
-        _identifier(escapedInQuotes: true);
+        _identifier(escapeChar: $double_quote);
         break;
       case $backquote:
         if (scanMoorTokens) {
           _inlineDart();
         } else {
-          _unexpectedToken();
+          _identifier(escapeChar: $backquote);
         }
         break;
       case $space:
@@ -366,10 +366,10 @@ class Scanner {
     }
   }
 
-  void _identifier({bool escapedInQuotes = false}) {
-    if (escapedInQuotes) {
+  void _identifier({int escapeChar}) {
+    if (escapeChar != null) {
       // find the closing quote
-      while (!_isAtEnd && _peek() != $double_quote) {
+      while (!_isAtEnd && _peek() != escapeChar) {
         _nextChar();
       }
       // Issue an error if the column name is unterminated
@@ -377,7 +377,7 @@ class Scanner {
         errors
             .add(TokenizerError('Unterminated column name', _currentLocation));
       } else {
-        // consume the closing double quote
+        // consume the closing char
         _nextChar();
         tokens.add(IdentifierToken(true, _currentSpan));
       }

--- a/sqlparser/test/scanner/scanner_test.dart
+++ b/sqlparser/test/scanner/scanner_test.dart
@@ -15,4 +15,20 @@ void main() {
       throwsA(isA<CumulatedTokenizerException>()),
     );
   });
+
+  test('scans identifiers with backticks', () {
+    expect(
+      Scanner('`SELECT`').scanTokens(),
+      contains(isA<IdentifierToken>()
+          .having((e) => e.identifier, 'identifier', 'SELECT')),
+    );
+  });
+
+  test('scans identifiers with double quotes', () {
+    expect(
+      Scanner('"SELECT"').scanTokens(),
+      contains(isA<IdentifierToken>()
+          .having((e) => e.identifier, 'identifier', 'SELECT')),
+    );
+  });
 }


### PR DESCRIPTION
Hi! I noticed that moor/sqlparser does not accept backticks as delimiters of identifiers. As sqlite *does* accept them, to retain some compatibility with mysql (see https://sqlite.org/lang_keywords.html), I thought it might be good to add them.

If you want me to add tests for this, please tell me what you want to see :)