### PR TITLE
Docs links move /kripken/sql.js ->/sql-js/sql.js

### DIFF
--- a/docs/content/en/docs/Other engines/web.md
+++ b/docs/content/en/docs/Other engines/web.md
@@ -32,7 +32,7 @@ Moor web is built on top of the [sql.js](https://github.com/sql-js/sql.js/) libr
 <body></body>
 </html>
 ```
-You can grab the latest version of `sql-wasm.js` and `sql-wasm.wasm` [here](https://github.com/sql-js/sql.js/tree/master/dist)
+You can grab the latest version of `sql-wasm.js` and `sql-wasm.wasm` [here](https://github.com/sql-js/sql.js/releases)
 and copy them into your `web` folder.
 
 A full example that works on the web (and all other platforms) is available

--- a/docs/content/en/docs/Other engines/web.md
+++ b/docs/content/en/docs/Other engines/web.md
@@ -20,7 +20,7 @@ class MyDatabase extends _$MyDatabase {
   MyDatabase() : super(WebDatabase('app'));
 ```
 
-Moor web is built on top of the [sql.js](https://github.com/kripken/sql.js/) library, which you need to include:
+Moor web is built on top of the [sql.js](https://github.com/sql-js/sql.js/) library, which you need to include:
 ```html
 <!doctype html>
 <html lang="en">
@@ -32,7 +32,7 @@ Moor web is built on top of the [sql.js](https://github.com/kripken/sql.js/) lib
 <body></body>
 </html>
 ```
-You can grab the latest version of `sql-wasm.js` and `sql-wasm.wasm` [here](https://github.com/kripken/sql.js/tree/master/dist)
+You can grab the latest version of `sql-wasm.js` and `sql-wasm.wasm` [here](https://github.com/sql-js/sql.js/tree/master/dist)
 and copy them into your `web` folder.
 
 A full example that works on the web (and all other platforms) is available
@@ -74,7 +74,7 @@ SharedDatabase constructDb() {
 You can see all queries sent from moor to the underlying database engine by enabling the `logStatements`
 parameter on the `WebDatabase` - they will appear in the console.
 When you have assertions enabled (e.g. in debug mode), moor will expose the underlying 
-[database](http://kripken.github.io/sql.js/documentation/#http://kripken.github.io/sql.js/documentation/class/Database.html)
+[database](http://sql-js.github.io/sql.js/documentation/#http://sql-js.github.io/sql.js/documentation/class/Database.html)
 object via `window.db`. If you need to quickly run a query to check the state of the database, you can use
 `db.exec(sql)`.
 If you need to delete your databases, there stored using local storage. You can clear all your data with `localStorage.clear()`.

--- a/docs/content/en/docs/_index.md
+++ b/docs/content/en/docs/_index.md
@@ -10,7 +10,7 @@ description: Welcome to the moor documentation. This site shows you what moor ca
 
 ## So what's moor?
 Moor is a reactive persistence library for Dart and Flutter applications. It's built on top
-of database libraries like [sqflite](https://pub.dev/packages/sqflite) or [sql.js](https://github.com/kripken/sql.js/)
+of database libraries like [sqflite](https://pub.dev/packages/sqflite) or [sql.js](https://github.com/sql-js/sql.js/)
 and provides additional features, like:
 
 - __Type safety__: Instead of writing sql queries manually and parsing the `List<Map<String, dynamic>>` that they 

--- a/moor/lib/moor_web.dart
+++ b/moor/lib/moor_web.dart
@@ -1,4 +1,4 @@
-/// A version of moor that runs on the web by using [sql.js](https://github.com/kripken/sql.js)
+/// A version of moor that runs on the web by using [sql.js](https://github.com/sql-js/sql.js)
 /// You manually need to include that library into your website to use the
 /// web version of moor. See [the documentation](https://moor.simonbinder.eu/web)
 /// for a more detailed instruction.

--- a/moor/lib/src/web/binary_string_conversion.dart
+++ b/moor/lib/src/web/binary_string_conversion.dart
@@ -35,7 +35,7 @@ class _Bin2String extends Converter<Uint8List, String> {
   const _Bin2String();
 
   // There is a browser limit on the amount of chars one can give to
-  // String.fromCharCodes https://github.com/kripken/sql.js/wiki/Persisting-a-Modified-Database#save-a-database-to-a-string
+  // String.fromCharCodes https://github.com/sql-js/sql.js/wiki/Persisting-a-Modified-Database#save-a-database-to-a-string
   static const int _chunkSize = 0xffff;
 
   @override


### PR DESCRIPTION
As described at https://github.com/kripken/sql.js the repo has been moved and due to this some links look outdated. 

Next issue:
At https://moor.simonbinder.eu/web/ there's text "You can grab the latest version of sql-wasm.js and sql-wasm.wasm *here* "
Now 'here' leads to 404. If we replace /kripken/ with /sql-js/ the link will look like https://github.com/sql-js/sql.js/tree/master/dist. The page exists, but content is not we want - there's no any *.js files. 
In this PR the link is replaced with https://github.com/sql-js/sql.js/releases 