### PR TITLE
Make DefaultValueSerializer null-safe for blobs

### DIFF
--- a/extras/integration_tests/flutter_db/pubspec.lock
+++ b/extras/integration_tests/flutter_db/pubspec.lock
@@ -180,14 +180,14 @@ packages:
       path: "../../../moor"
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.2.0"
   moor_ffi:
     dependency: "direct main"
     description:
       path: "../../../moor_ffi"
       relative: true
     source: path
-    version: "0.7.0-dev"
+    version: "0.7.0"
   moor_flutter:
     dependency: "direct main"
     description:

--- a/moor/lib/src/runtime/data_class.dart
+++ b/moor/lib/src/runtime/data_class.dart
@@ -163,12 +163,12 @@ class _DefaultValueSerializer extends ValueSerializer {
 
   @override
   T fromJson<T>(dynamic json) {
+    if (json == null) {
+      return null;
+    }
+
     if (T == DateTime) {
-      if (json == null) {
-        return null;
-      } else {
-        return DateTime.fromMillisecondsSinceEpoch(json as int) as T;
-      }
+      return DateTime.fromMillisecondsSinceEpoch(json as int) as T;
     }
 
     if (T == double && json is int) {

--- a/moor/lib/src/runtime/query_builder/schema/table_info.dart
+++ b/moor/lib/src/runtime/query_builder/schema/table_info.dart
@@ -59,7 +59,7 @@ mixin TableInfo<TableDsl extends Table, D extends DataClass> on Table
   /// Converts a [companion] to the real model class, [D].
   ///
   /// Values that are [Value.absent] in the companion will be set to `null`.
-  D mapFromCompanion(UpdateCompanion<D> companion) {
+  D mapFromCompanion(Insertable<D> companion) {
     final asColumnMap = companion.toColumns(false);
 
     if (asColumnMap.values.any((e) => e is! Variable)) {

--- a/moor_ffi/CHANGELOG.md
+++ b/moor_ffi/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1
+
+- Fix `libsqlite3.so` not being included in new Flutter builds for Android
+
 ## 0.7.0
 
 - Throw an error when using an unsupported datatype as argument

--- a/moor_ffi/android/src/main/java/eu/simonbinder/moor_ffi/MoorFfiPlugin.java
+++ b/moor_ffi/android/src/main/java/eu/simonbinder/moor_ffi/MoorFfiPlugin.java
@@ -1,0 +1,17 @@
+package eu.simonbinder.moor_ffi;
+
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+
+public class MoorFfiPlugin implements FlutterPlugin {
+
+    @Override
+    public void onAttachedToEngine(FlutterPluginBinding binding) {
+        // Do nothing, we only need the native libraries.
+    }
+
+    @Override
+    public void onDetachedFromEngine(FlutterPluginBinding binding) {
+        // Again, nothing to do here.
+    }
+
+}

--- a/moor_ffi/pubspec.yaml
+++ b/moor_ffi/pubspec.yaml
@@ -1,6 +1,6 @@
 name: moor_ffi
 description: "Provides sqlite bindings using dart:ffi, including a moor executor"
-version: 0.7.0
+version: 0.7.1
 homepage: https://github.com/simolus3/moor/tree/develop/moor_ffi
 issue_tracker: https://github.com/simolus3/moor/issues
 

--- a/moor_ffi/pubspec.yaml
+++ b/moor_ffi/pubspec.yaml
@@ -23,6 +23,10 @@ dev_dependencies:
 
 flutter:
   plugin:
-    # the flutter.plugin key needs to exists so that this project gets recognized as a plugin when imported. We need to
-    # get recognized as a plugin so that our build scripts are executed.
-    foo: bar
+    platforms:
+      # At the moment, we only have a custom build script for Android. For that to be included, we have to provide a
+      # plugin class (even though moor_ffi contains no platform-specific code). The plugin class is just an empty stub
+      # here.
+      android:
+        pluginClass: MoorFfiPlugin
+        package: eu.simonbinder.moor_ffi


### PR DESCRIPTION
This fixes an issue where a nullable blob column, e.g. `BlobColumn get logic => blob().nullable()();` will throw an error that looks like `NoSuchMethodError: The method 'cast' was called on null.`