### PR TITLE
Make DefaultValueSerializer null-safe for blobs

### DIFF
--- a/moor/lib/src/runtime/data_class.dart
+++ b/moor/lib/src/runtime/data_class.dart
@@ -163,12 +163,12 @@ class _DefaultValueSerializer extends ValueSerializer {
 
   @override
   T fromJson<T>(dynamic json) {
+    if (json == null) {
+      return null;
+    }
+
     if (T == DateTime) {
-      if (json == null) {
-        return null;
-      } else {
-        return DateTime.fromMillisecondsSinceEpoch(json as int) as T;
-      }
+      return DateTime.fromMillisecondsSinceEpoch(json as int) as T;
     }
 
     if (T == double && json is int) {


### PR DESCRIPTION
This fixes an issue where a nullable blob column, e.g. `BlobColumn get logic => blob().nullable()();` will throw an error that looks like `NoSuchMethodError: The method 'cast' was called on null.`

(cherry picked from commit 87937ba89b28e956963555d7a456b61b67500043)