### PR TITLE
Support table migration with autoindexes

### DIFF
--- a/moor/test/integration_tests/migrations_integration_test.dart
+++ b/moor/test/integration_tests/migrations_integration_test.dart
@@ -15,7 +15,8 @@ void main() {
           title TEXT NOT NULL,
           content TEXT NOT NULL,
           target_date INTEGER NOT NULL,
-          category TEXT NOT NULL
+          category TEXT NOT NULL,
+          UNIQUE(title, category)
         );
       ''');
 


### PR DESCRIPTION
Not sure this is the correct solution but it seems that autoindexes are always derived from the `CREATE TABLE` statement/constraints and should not be migrated by manually.