### PR TITLE
Fixed typo. j doesn't exist. The variable is p.

### DIFF
--- a/docs/content/en/docs/Other engines/vm.md
+++ b/docs/content/en/docs/Other engines/vm.md
@@ -65,7 +65,7 @@ import 'package:path/path.dart' as p;
 
 LazyDatabase(() async {
   final dbFolder = await getDatabasesPath();
-  final file = File(j.join(dbFolder, 'db.sqlite'));
+  final file = File(p.join(dbFolder, 'db.sqlite'));
   return VmDatabase(file);
 })
 ```


### PR DESCRIPTION
The path library has been imported as p not j.