### PR TITLE
sqflite_sqlcipher nnbd version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ pubspec.lock
 .dart_tool/
 
 benchmark_results.json
+.flutter-plugins
 .flutter-plugins-dependencies
 flutter_export_environment.sh

--- a/extras/encryption/pubspec.yaml
+++ b/extras/encryption/pubspec.yaml
@@ -4,11 +4,11 @@ version: 1.0.0
 author: Simon Binder <oss@simonbinder.eu>
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
   moor: ^3.0.0
-  sqflite_sqlcipher: ^1.0.0+6
+  sqflite_sqlcipher: ^2.0.0-nullsafety
 
 dependency_overrides:
   moor:

--- a/moor/pubspec.yaml
+++ b/moor/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   meta: ^1.3.0-nullsafety.6
   convert: ^3.0.0-nullsafety
   collection: ^1.15.0-nullsafety.5
-  synchronized: ^2.1.0
+  synchronized: ^3.0.0-nullsafety
   pedantic: ^1.10.0-nullsafety.3
   sqlite3: ^0.1.9-nullsafety
 
@@ -33,12 +33,6 @@ dependency_overrides:
     path: ../moor_generator
   sqlparser:
     path: ../sqlparser
-
-  synchronized:
-    git:
-      url: https://github.com/tekartik/synchronized.dart.git
-      ref: null_safety
-      path: synchronized
 
   # Remove after https://github.com/dart-lang/mockito/issues/297 is fixed
   mockito:


### PR DESCRIPTION
I've migrated the sqlcipher package to null safety.
Locally I see a bunch of errors in packages such as the generator or the integration tests. Is that normal? I suppose not all the project is yet migrated.