### PR TITLE
nnbd migration of encrypted_moor and moor_flutter

### DIFF
--- a/moor_flutter/lib/moor_flutter.dart
+++ b/moor_flutter/lib/moor_flutter.dart
@@ -6,7 +6,6 @@ library moor_flutter;
 
 import 'dart:async';
 import 'dart:io';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart';
 import 'package:moor/moor.dart';
 import 'package:moor/backends.dart';
@@ -21,20 +20,19 @@ typedef DatabaseCreator = FutureOr<void> Function(File file);
 
 class _SqfliteDelegate extends DatabaseDelegate with _SqfliteExecutor {
   @override
-  s.Database db;
+  late s.Database db;
+  bool _isOpen = false;
 
   final bool inDbFolder;
   final String path;
 
   bool singleInstance;
-  final DatabaseCreator creator;
+  final DatabaseCreator? creator;
 
   _SqfliteDelegate(this.inDbFolder, this.path,
-      {this.singleInstance, this.creator}) {
-    singleInstance ??= true;
-  }
+      {this.singleInstance = true, this.creator});
 
-  DbVersionDelegate _delegate;
+  DbVersionDelegate? _delegate;
   @override
   DbVersionDelegate get versionDelegate {
     return _delegate ??= _SqfliteVersionDelegate(db);
@@ -45,20 +43,20 @@ class _SqfliteDelegate extends DatabaseDelegate with _SqfliteExecutor {
       _SqfliteTransactionDelegate(this);
 
   @override
-  bool get isOpen => db != null;
+  bool get isOpen => _isOpen;
 
   @override
   Future<void> open(QueryExecutorUser user) async {
     String resolvedPath;
     if (inDbFolder) {
-      resolvedPath = join(await s.getDatabasesPath(), path);
+      resolvedPath = join((await s.getDatabasesPath())!, path);
     } else {
       resolvedPath = path;
     }
 
     final file = File(resolvedPath);
     if (creator != null && !await file.exists()) {
-      await creator(file);
+      await creator!(file);
     }
 
     // default value when no migration happened
@@ -66,6 +64,7 @@ class _SqfliteDelegate extends DatabaseDelegate with _SqfliteExecutor {
       resolvedPath,
       singleInstance: singleInstance,
     );
+    _isOpen = true;
   }
 
   @override
@@ -131,23 +130,23 @@ mixin _SqfliteExecutor on QueryDelegate {
   }
 
   @override
-  Future<void> runCustom(String statement, List args) {
+  Future<void> runCustom(String statement, List<Object?> args) {
     return db.execute(statement, args);
   }
 
   @override
-  Future<int> runInsert(String statement, List args) {
+  Future<int> runInsert(String statement, List<Object?> args) {
     return db.rawInsert(statement, args);
   }
 
   @override
-  Future<QueryResult> runSelect(String statement, List args) async {
+  Future<QueryResult> runSelect(String statement, List<Object?> args) async {
     final result = await db.rawQuery(statement, args);
     return QueryResult.fromRows(result);
   }
 
   @override
-  Future<int> runUpdate(String statement, List args) {
+  Future<int> runUpdate(String statement, List<Object?> args) {
     return db.rawUpdate(statement, args);
   }
 }
@@ -165,10 +164,10 @@ class FlutterQueryExecutor extends DelegatedDatabase {
   /// [MigrationStrategy.onCreate] callback because it hasn't been created by
   /// moor.
   FlutterQueryExecutor(
-      {@required String path,
-      bool logStatements,
-      bool singleInstance,
-      DatabaseCreator creator})
+      {required String path,
+      bool? logStatements,
+      bool singleInstance = true,
+      DatabaseCreator? creator})
       : super(
             _SqfliteDelegate(false, path,
                 singleInstance: singleInstance, creator: creator),
@@ -186,10 +185,10 @@ class FlutterQueryExecutor extends DelegatedDatabase {
   /// [MigrationStrategy.onCreate] callback because it hasn't been created by
   /// moor.
   FlutterQueryExecutor.inDatabaseFolder(
-      {@required String path,
-      bool logStatements,
-      bool singleInstance,
-      DatabaseCreator creator})
+      {required String path,
+      bool? logStatements,
+      bool singleInstance = true,
+      DatabaseCreator? creator})
       : super(
             _SqfliteDelegate(true, path,
                 singleInstance: singleInstance, creator: creator),
@@ -206,8 +205,8 @@ class FlutterQueryExecutor extends DelegatedDatabase {
   ///
   /// Note that this returns null until the moor database has been opened.
   /// A moor database is opened lazily when the first query runs.
-  s.Database get sqfliteDb {
+  s.Database? get sqfliteDb {
     final sqfliteDelegate = delegate as _SqfliteDelegate;
-    return sqfliteDelegate.db;
+    return sqfliteDelegate.isOpen ? sqfliteDelegate.db : null;
   }
 }

--- a/moor_flutter/pubspec.lock
+++ b/moor_flutter/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0-nullsafety.3"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.3"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0-nullsafety.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.3"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0-nullsafety.5"
   convert:
     dependency: transitive
     description:
@@ -56,7 +56,14 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0-nullsafety.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -73,35 +80,35 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10-nullsafety.3"
   meta:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.4"
+    version: "1.3.0-nullsafety.6"
   moor:
     dependency: "direct main"
     description:
-      name: moor
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.0"
+      path: "../moor"
+      relative: true
+    source: path
+    version: "3.5.0-dev"
   path:
     dependency: "direct main"
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0-nullsafety.3"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.10.0-nullsafety.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -113,77 +120,84 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0-nullsafety.4"
   sqflite:
     dependency: "direct main"
     description:
       name: sqflite
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "2.0.0-nullsafety.2"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0+1"
+    version: "2.0.0-nullsafety.2"
+  sqlite3:
+    dependency: transitive
+    description:
+      name: sqlite3
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.9-nullsafety.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.2"
+    version: "1.10.0-nullsafety.6"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.3"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.3"
   synchronized:
     dependency: transitive
     description:
       name: synchronized
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.0-nullsafety.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19-nullsafety.6"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.5"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0-nullsafety.5"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-213.1.beta"
-  flutter: ">=1.10.1 <2.0.0"
+  dart: ">=2.12.0-29 <3.0.0"
+  flutter: ">=1.24.0-10 <2.0.0"

--- a/moor_flutter/pubspec.yaml
+++ b/moor_flutter/pubspec.yaml
@@ -1,18 +1,17 @@
 name: moor_flutter
 description: Flutter implementation of moor, a safe and reactive persistence library for Dart applications
-version: 3.1.0
+version: 4.0.0-nullsafety
 repository: https://github.com/simolus3/moor
 homepage: https://moor.simonbinder.eu/
 issue_tracker: https://github.com/simolus3/moor/issues
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
   moor: ^3.0.0
-  sqflite: ^1.1.6+5
-  meta: ^1.0.0
-  path: ^1.0.0
+  sqflite: '>=2.0.0-nullsafety <3.0.0'
+  path: '>1.8.0-nullsafety <2.0.0'
   flutter:
     sdk: flutter
 
@@ -20,9 +19,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-#dependency_overrides:
-#  moor:
-#    path: ../moor
+dependency_overrides:
+ moor:
+   path: ../moor
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec


### PR DESCRIPTION
Missing changes from #936 

I'm not sure how you'd like to handle the `List<Object>` casting. The null safety API from sqflite now expects `List<Object>` instead of `List<dynamic>` because null values cannot be bound as arguments.
In the end I was able to run the integration tests correctly. I had to override the `convert` dependency with the null safety version though.