### PR TITLE
Update cli version to 0.2.0

### DIFF
--- a/moor_generator/pubspec.yaml
+++ b/moor_generator/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   # CLI
   args: ^1.5.0
   logging: '>=0.11.0 <1.0.0'
-  cli_util: ^0.1.0
+  cli_util: ^0.2.0
 
   # Moor-specific analysis
   moor: ^3.0.0


### PR DESCRIPTION
Because moor_generator >=2.2.0 depends on cli_util ^0.1.0 and dev_dependencies depend on cli_util 0.2.0