### PR TITLE
Correctly fallback to LocalStorage in private mode on Firefox when using indexedDbIfSupported()

### DIFF
--- a/docs/content/en/docs/Advanced Features/type_converters.md
+++ b/docs/content/en/docs/Advanced Features/type_converters.md
@@ -76,6 +76,11 @@ The generated `User` class will then have a `preferences` column of type
 the object in `select`, `update` and `insert` statements. This feature
 also works with [compiled custom queries]({{ "/queries/custom" | absolute_url }}).
 
+{{% alert title="Caution with equality" color="warning"  %}}
+> If your converter returns an object that is not comparable by value, the generated dataclass will not
+  be comparable by value.
+{{% /alert %}}
+
 ### Implicit enum converters
 
 A common scenario for type converters is to map between enums and integers by representing enums

--- a/docs/content/en/docs/Getting started/advanced_dart_tables.md
+++ b/docs/content/en/docs/Getting started/advanced_dart_tables.md
@@ -131,7 +131,7 @@ Note that the primary key must essentially be constant so that the generator can
 Moor supports a variety of column types out of the box. You can store custom classes in columns by using
 [type converters]({{<relref "../Advanced Features/type_converters.md">}}).
 
-| Dart type    | Colum         | Corresponding SQLite type                           |
+| Dart type    | Column        | Corresponding SQLite type                           |
 |--------------|---------------|-----------------------------------------------------|
 | `int`        | `integer()`   | `INTEGER`                                           |
 | `double`     | `real()`      | `REAL`                                              |

--- a/docs/content/en/docs/Getting started/writing_queries.md
+++ b/docs/content/en/docs/Getting started/writing_queries.md
@@ -227,7 +227,7 @@ encountered a word. A table for that might look like
 ```dart
 class Words extends Table {
   TextColumn get word => text()();
-  IntColumn get usages => integer().default(const Constant(1))();
+  IntColumn get usages => integer().withDefault(const Constant(1))();
 
   @override
   Set<Column> get primaryKey => {word};

--- a/docs/content/en/docs/Other engines/vm.md
+++ b/docs/content/en/docs/Other engines/vm.md
@@ -65,7 +65,7 @@ import 'package:path/path.dart' as p;
 
 LazyDatabase(() async {
   final dbFolder = await getDatabasesPath();
-  final file = File(j.join(dbFolder, 'db.sqlite'));
+  final file = File(p.join(dbFolder, 'db.sqlite'));
   return VmDatabase(file);
 })
 ```
@@ -162,5 +162,5 @@ Future<List<Coordinate>> findNearby(Coordinate center, int radius) {
 }
 ```
 
-Aller the other functions are available under a similar name (`sqlSin`, `sqlCos`, `sqlAtan` and so on).
+All the other functions are available under a similar name (`sqlSin`, `sqlCos`, `sqlAtan` and so on).
 They have that `sql` prefix to avoid clashes with `dart:math`.

--- a/docs/content/en/docs/Other engines/web.md
+++ b/docs/content/en/docs/Other engines/web.md
@@ -90,7 +90,7 @@ performant, since we don't have to encode binary blobs as strings.
 To use this implementation on browsers that support it, replace `WebDatabase(name)` with:
 
 ```dart
-WebDatabase.withStorage(MoorWebStorage.indexedDbIfSupported(name))
+WebDatabase.withStorage(await MoorWebStorage.indexedDbIfSupported(name))
 ```
 
-Moor will automatically migrate data from local storage to `IndexeDb` when it is available.
+Moor will automatically migrate data from local storage to `IndexedDb` when it is available.

--- a/docs/content/en/docs/platforms.md
+++ b/docs/content/en/docs/platforms.md
@@ -115,8 +115,8 @@ void main() {
 }
 
 DynamicLibrary _openOnLinux() {
-  final scriptDir = File(Platform.script.toFilePath()).parent;
-  final libraryNextToScript = File('${scriptDir.path}/sqlite3.so');
+  final script = File(Platform.script.toFilePath());
+  final libraryNextToScript = File('${script.parent.path}/sqlite3.so');
   return DynamicLibrary.open(libraryNextToScript.path);
 }
 // _openOnWindows could be implemented similarly by opening `sqlite3.dll`

--- a/moor/lib/src/dsl/database.dart
+++ b/moor/lib/src/dsl/database.dart
@@ -70,7 +70,7 @@ class UseMoor {
 /// if you have a class called `MyDatabase`, this could look like this:
 /// ```dart
 /// class MyDao extends DatabaseAccessor<MyDatabase> {
-///   TodosDao(MyDatabase db) : super(db);
+///   MyDao(MyDatabase db) : super(db);
 /// }
 /// ```
 /// After having run the build step once more, moor will have generated a mixin

--- a/moor/lib/src/web/storage.dart
+++ b/moor/lib/src/web/storage.dart
@@ -47,22 +47,28 @@ abstract class MoorWebStorage {
 
   /// Uses [MoorWebStorage.indexedDb] if the current browser supports it.
   /// Otherwise, falls back to the local storage based implementation.
-  factory MoorWebStorage.indexedDbIfSupported(String name,
-      {bool inWebWorker = false}) {
-    return supportsIndexedDb(inWebWorker: inWebWorker)
+  static Future<MoorWebStorage> indexedDbIfSupported(String name,
+      {bool inWebWorker = false}) async {
+    return await supportsIndexedDb(inWebWorker: inWebWorker)
         ? MoorWebStorage.indexedDb(name, inWebWorker: inWebWorker)
         : MoorWebStorage(name);
   }
 
   /// Attempts to check whether the current browser supports the
   /// [MoorWebStorage.indexedDb] storage implementation.
-  static bool supportsIndexedDb({bool inWebWorker = false}) {
+  static Future<bool> supportsIndexedDb({bool inWebWorker = false}) async {
     var isIndexedDbSupported = false;
     if (inWebWorker && WorkerGlobalScope.instance.indexedDB != null) {
       isIndexedDbSupported = true;
     } else {
       try {
         isIndexedDbSupported = IdbFactory.supported;
+
+        // Try opening a mock database to check if IndexedDB is really
+        // available. This avoids the problem with Firefox incorrectly
+        // reporting IndexedDB as supported in private mode.
+        final mockDb = await window.indexedDB.open('moor_mock_db');
+        mockDb.close();
       } catch (error) {
         isIndexedDbSupported = false;
       }


### PR DESCRIPTION
`indexedDbIfSupported()` is no longer a factory as factories cannot be async.

You'll probably want to squash this PR 😅

Fixes #982 