### PR TITLE
Correctly fallback to LocalStorage in private mode on Firefox when using indexedDbIfSupported()

### DIFF
--- a/docs/content/en/docs/Other engines/web.md
+++ b/docs/content/en/docs/Other engines/web.md
@@ -90,7 +90,7 @@ performant, since we don't have to encode binary blobs as strings.
 To use this implementation on browsers that support it, replace `WebDatabase(name)` with:
 
 ```dart
-WebDatabase.withStorage(MoorWebStorage.indexedDbIfSupported(name))
+WebDatabase.withStorage(await MoorWebStorage.indexedDbIfSupported(name))
 ```
 
 Moor will automatically migrate data from local storage to `IndexeDb` when it is available.


### PR DESCRIPTION
`indexedDbIfSupported()` is no longer a factory as factories cannot be async.

You'll probably want to squash this PR 😅

Fixes #982

Edit: Failed to rebase the previous branch properly, here's a new one.