### PR TITLE
Fix converter data types when NNBD is off

### DIFF
--- a/moor_generator/lib/src/model/types.dart
+++ b/moor_generator/lib/src/model/types.dart
@@ -44,7 +44,8 @@ extension OperationOnTypes on HasType {
   /// [int].
   String dartTypeCode([GenerationOptions options = const GenerationOptions()]) {
     if (typeConverter != null) {
-      final needsSuffix = nullable && !typeConverter.hasNullableDartType;
+      final needsSuffix =
+          options.nnbd && nullable && !typeConverter.hasNullableDartType;
       final baseType = typeConverter.mappedType.codeString(options);
 
       return needsSuffix ? '$baseType?' : baseType;


### PR DESCRIPTION
This should fix the converter data types having a nullable suffix when NNBD is off.
Discovered/Documented in https://github.com/simolus3/moor/issues/964