### PR TITLE
Break Selectable methods into smaller interfaces based on return type.

### DIFF
--- a/docs/pages/docs/Getting started/writing_queries.md
+++ b/docs/pages/docs/Getting started/writing_queries.md
@@ -107,11 +107,11 @@ MultiSelectable<Todo> pageOfTodos(int page, {int pageSize = 10}) {
 }
 
 // Exposes `getSingle` and `watchSingle`
-SingleSelectable<Todo> todoById(int id) =>
+SingleSelectable<Todo> entryById(int id) =>
   select(todos)..where((t) => t.id.equals(id));
 
 // Exposes `getSingleOrNull` and `watchSingleOrNull`
-SingleOrNullSelectable<Todo> todoFromExternalLink(int id) =>
+SingleOrNullSelectable<Todo> entryFromExternalLink(int id) =>
   select(todos)..where((t) => t.id.equals(id));
 ```
 These base classes don't have query-building or `map` methods, signaling to the consumer

--- a/docs/pages/docs/Getting started/writing_queries.md
+++ b/docs/pages/docs/Getting started/writing_queries.md
@@ -84,7 +84,6 @@ more than one entry (which is impossible in this case), an error will be added
 instead.
 
 ### Mapping
-
 Before calling `watch` or `get` (or the single variants), you can use `map` to transform
 the result. 
 ```dart
@@ -98,6 +97,25 @@ Stream<List<String>> contentWithLongTitles() {
 }
 ```
 
+### Deferring get vs watch
+If you want to make your query consumable as either a `Future` or a `Stream`,
+you can refine your return type using one of the `Selectable` abstract base classes;
+```dart
+// Exposes `get` and `watch`
+MultiSelectable<Todo> pageOfTodos(int page, {int pageSize = 10}) {
+  return select(todos)..limit(pageSize, offset: page - 1);
+}
+
+// Exposes `getSingle` and `watchSingle`
+SingleSelectable<Todo> todoById(int id) =>
+  select(todos)..where((t) => t.id.equals(id));
+
+// Exposes `getSingleOrNull` and `watchSingleOrNull`
+SingleOrNullSelectable<Todo> todoFromExternalLink(int id) =>
+  select(todos)..where((t) => t.id.equals(id));
+```
+These base classes don't have query-building or `map` methods, signaling to the consumer
+that they are complete results.
 
 If you need more complex queries with joins or custom columns, see [this site]({{ "../Advanced Features/joins.md" | pageUrl }}).
 

--- a/docs/pages/docs/Getting started/writing_queries.md
+++ b/docs/pages/docs/Getting started/writing_queries.md
@@ -102,9 +102,8 @@ If you want to make your query consumable as either a `Future` or a `Stream`,
 you can refine your return type using one of the `Selectable` abstract base classes;
 ```dart
 // Exposes `get` and `watch`
-MultiSelectable<Todo> pageOfTodos(int page, {int pageSize = 10}) {
-  return select(todos)..limit(pageSize, offset: page - 1);
-}
+MultiSelectable<Todo> pageOfTodos(int page, {int pageSize = 10}) =>
+  select(todos)..limit(pageSize, offset: page);
 
 // Exposes `getSingle` and `watchSingle`
 SingleSelectable<Todo> entryById(int id) =>

--- a/docs/pages/docs/Getting started/writing_queries.md
+++ b/docs/pages/docs/Getting started/writing_queries.md
@@ -102,16 +102,19 @@ If you want to make your query consumable as either a `Future` or a `Stream`,
 you can refine your return type using one of the `Selectable` abstract base classes;
 ```dart
 // Exposes `get` and `watch`
-MultiSelectable<Todo> pageOfTodos(int page, {int pageSize = 10}) =>
-  select(todos)..limit(pageSize, offset: page);
+MultiSelectable<Todo> pageOfTodos(int page, {int pageSize = 10}) {
+  return select(todos)..limit(pageSize, offset: page);
+}
 
 // Exposes `getSingle` and `watchSingle`
-SingleSelectable<Todo> entryById(int id) =>
-  select(todos)..where((t) => t.id.equals(id));
+SingleSelectable<Todo> entryById(int id) {
+  return select(todos)..where((t) => t.id.equals(id));
+}
 
 // Exposes `getSingleOrNull` and `watchSingleOrNull`
-SingleOrNullSelectable<Todo> entryFromExternalLink(int id) =>
-  select(todos)..where((t) => t.id.equals(id));
+SingleOrNullSelectable<Todo> entryFromExternalLink(int id) {
+  return select(todos)..where((t) => t.id.equals(id));
+}
 ```
 These base classes don't have query-building or `map` methods, signaling to the consumer
 that they are complete results.

--- a/docs/pages/docs/Other engines/vm.md
+++ b/docs/pages/docs/Other engines/vm.md
@@ -73,7 +73,7 @@ LazyDatabase(() async {
 ```
 
 Note: If you haven't shipped a version with `moor_flutter` to your users yet, you can drop the dependency
-on `sqflite`. Instead, you can use `path_provider` which [works on Desktop](https://github.com/google/flutter-desktop-embedding/tree/master/plugins/flutter_plugins).
+on `sqflite`. Instead, you can use `path_provider` which [works on Desktop](https://pub.dev/packages/path_provider).
 Please be aware that `FlutterQueryExecutor.inDatabaseFolder` might yield a different folder than
 `path_provider` on Android. This can cause data loss if you've already shipped a version using
 `moor_flutter`. In that case, using `getDatabasePath` from sqflite is the suggested solution.

--- a/moor/lib/src/runtime/query_builder/statements/query.dart
+++ b/moor/lib/src/runtime/query_builder/statements/query.dart
@@ -76,9 +76,8 @@ abstract class Query<T extends Table, D extends DataClass> extends Component {
 /// {@template moor_multi_selectable_example}
 /// ```dart
 /// /// Retrieve a page of [Todo]s.
-/// MultiSelectable<Todo> pageOfTodos(int page, {int pageSize = 10}) {
-///   return select(todos)..limit(pageSize, offset: page - 1);
-/// }
+/// MultiSelectable<Todo> pageOfTodos(int page, {int pageSize = 10}) =>
+///   select(todos)..limit(pageSize, offset: page);
 /// pageOfTodos(1).get();
 /// pageOfTodos(1).watch();
 /// ```

--- a/moor/lib/src/runtime/query_builder/statements/query.dart
+++ b/moor/lib/src/runtime/query_builder/statements/query.dart
@@ -68,19 +68,22 @@ abstract class Query<T extends Table, D extends DataClass> extends Component {
   }
 }
 
-/// Abstract class for queries which can return one-time values or a stream
-/// of values.
-abstract class Selectable<T> {
+/// [Selectable] methods for returning multiple results.
+abstract class MultiSelectable<T> {
   /// Executes this statement and returns the result.
   Future<List<T>> get();
 
   /// Creates an auto-updating stream of the result that emits new items
   /// whenever any table used in this statement changes.
   Stream<List<T>> watch();
+}
 
-  /// Executes this statement, like [get], but only returns one value. If the
-  /// query returns no or too many rows, the returned future will complete with
-  /// an error.
+/// [Selectable] methods for returning or streaming single,
+/// non-nullable results.
+abstract class SingleSelectable<T> {
+  /// Executes this statement, like [Selectable.get], but only returns one
+  /// value. the query returns no or too many rows, the returned future will
+  /// complete with an error.
   ///
   /// {@template moor_single_query_expl}
   /// Be aware that this operation won't put a limit clause on this statement,
@@ -99,20 +102,69 @@ abstract class Selectable<T> {
   /// clause will only allow one row.
   /// {@endtemplate}
   ///
-  /// See also: [getSingleOrNull], which returns `null` instead of throwing if
-  /// the query completes with no rows.
+  /// See also: [Selectable.getSingleOrNull], which returns `null` instead of
+  /// throwing if the query completes with no rows.
+  Future<T> getSingle();
+
+  /// Creates an auto-updating stream of this statement, similar to
+  /// [Selectable.watch]. However, it is assumed that the query will only emit
+  /// one result, so instead of returning a `Stream<List<T>>`, this returns a
+  /// `Stream<T>`. If, at any point, the query emits no or more than one rows,
+  /// an error will be added to the stream instead.
+  ///
+  /// {@macro moor_single_query_expl}
+  Stream<T> watchSingle();
+}
+
+/// [Selectable] methods for returning or streaming single,
+/// nullable results.
+abstract class SingleOrNullSelectable<T> {
+  /// Executes this statement, like [Selectable.get], but only returns one
+  /// value. If the result too many values, this method will throw. If no
+  /// row is returned, `null` will be returned instead.
+  ///
+  /// {@macro moor_single_query_expl}
+  ///
+  /// See also: [Selectable.getSingle], which can be used if the query will
+  /// always evaluate to exactly one row.
+  Future<T?> getSingleOrNull();
+
+  /// Creates an auto-updating stream of this statement, similar to
+  /// [Selectable.watch]. However, it is assumed that the query will only
+  /// emit one result, so instead of returning a `Stream<List<T>>`, this
+  /// returns a `Stream<T?>`. If the query emits more than one row at
+  /// some point, an error will be emitted to the stream instead.
+  /// If the query emits zero rows at some point, `null` will be added
+  /// to the stream instead.
+  ///
+  /// {@macro moor_single_query_expl}
+  Stream<T?> watchSingleOrNull();
+}
+
+/// Abstract class for queries which can return one-time values or a stream
+/// of values.
+abstract class Selectable<T>
+    implements
+        MultiSelectable<T>,
+        SingleSelectable<T>,
+        SingleOrNullSelectable<T> {
+  @override
+  Future<List<T>> get();
+
+  @override
+  Stream<List<T>> watch();
+
+  @override
   Future<T> getSingle() async {
     return (await get()).single;
   }
 
-  /// Executes this statement, like [get], but only returns one value. If the
-  /// result too many values, this method will throw. If no row is returned,
-  /// `null` will be returned instead.
-  ///
-  /// {@macro moor_single_query_expl}
-  ///
-  /// See also: [getSingle], which can be used if the query will never evaluate
-  /// to exactly one row.
+  @override
+  Stream<T> watchSingle() {
+    return watch().transform(singleElements());
+  }
+
+  @override
   Future<T?> getSingleOrNull() async {
     final list = await get();
     final iterator = list.iterator;
@@ -128,25 +180,7 @@ abstract class Selectable<T> {
     return element;
   }
 
-  /// Creates an auto-updating stream of this statement, similar to [watch].
-  /// However, it is assumed that the query will only emit one result, so
-  /// instead of returning a `Stream<List<T>>`, this returns a `Stream<T>`. If,
-  /// at any point, the query emits no or more than one rows, an error will be
-  /// added to the stream instead.
-  ///
-  /// {@macro moor_single_query_expl}
-  Stream<T> watchSingle() {
-    return watch().transform(singleElements());
-  }
-
-  /// Creates an auto-updating stream of this statement, similar to [watch].
-  /// However, it is assumed that the query will only emit one result, so
-  /// instead of returning a `Stream<List<T>>`, this returns a `Stream<T?>`. If
-  /// the query emits more than one row at some point, an error will be emitted
-  /// to the stream instead. If the query emits zero rows at some point, `null`
-  /// will be added to the stream instead.
-  ///
-  /// {@macro moor_single_query_expl}
+  @override
   Stream<T?> watchSingleOrNull() {
     return watch().transform(singleElementsOrNull());
   }

--- a/moor/lib/src/runtime/query_builder/statements/query.dart
+++ b/moor/lib/src/runtime/query_builder/statements/query.dart
@@ -69,6 +69,23 @@ abstract class Query<T extends Table, D extends DataClass> extends Component {
 }
 
 /// [Selectable] methods for returning multiple results.
+///
+/// Useful for refining the return type of a query, while still delegating
+/// whether to [get] or [watch] results to the consuming code.
+///
+/// {@template moor_multi_selectable_example}
+/// ```dart
+/// /// Retrieve a page of [Todo]s.
+/// MultiSelectable<Todo> pageOfTodos(int page, {int pageSize = 10}) {
+///   return select(todos)..limit(pageSize, offset: page - 1);
+/// }
+/// pageOfTodos(1).get();
+/// pageOfTodos(1).watch();
+/// ```
+/// {@endtemplate}
+///
+/// See also: [SingleSelectable] and [SingleOrNullSelectable] for exposing
+/// single value methods.
 abstract class MultiSelectable<T> {
   /// Executes this statement and returns the result.
   Future<List<T>> get();
@@ -80,6 +97,24 @@ abstract class MultiSelectable<T> {
 
 /// [Selectable] methods for returning or streaming single,
 /// non-nullable results.
+///
+/// Useful for refining the return type of a query, while still delegating
+/// whether to [getSingle] or [watchSingle] results to the consuming code.
+///
+/// {@template moor_single_selectable_example}
+/// ```dart
+/// // Retrieve a todo known to exist.
+/// SingleSelectable<Todo> entryById(int id) {
+///   return (select(todos)..where((t) => t.id.equals(id)));
+/// }
+/// final idGuaranteedToExist = 10;
+/// entryById(idGuaranteedToExist).getSingle();
+/// entryById(idGuaranteedToExist).watchSingle();
+/// ```
+/// {@endtemplate}
+///
+/// See also: [MultiSelectable] for exposing multi-value methods and
+/// [SingleOrNullSelectable] for exposing nullable value methods.
 abstract class SingleSelectable<T> {
   /// Executes this statement, like [Selectable.get], but only returns one
   /// value. the query returns no or too many rows, the returned future will
@@ -118,6 +153,25 @@ abstract class SingleSelectable<T> {
 
 /// [Selectable] methods for returning or streaming single,
 /// nullable results.
+///
+/// Useful for refining the return type of a query, while still delegating
+/// whether to [getSingleOrNull] or [watchSingleOrNull] result to the
+/// consuming code.
+///
+/// {@template moor_single_or_null_selectable_example}
+///```dart
+/// // Retrieve a todo from an external link that may not be valid.
+/// SingleOrNullSelectable<Todo> todoFromExternalLink(int id) =>
+///   select(todos)..where((t) => t.id.equals(id));
+///
+/// final idFromEmailLink = 100;
+/// todoFromExternalLink(idFromEmailLink).getSingleOrNull();
+/// todoFromExternalLink(idFromEmailLink).watchSingleOrNull();
+/// ```
+/// {@endtemplate}
+///
+/// See also: [MultiSelectable] for exposing multi-value methods and
+/// [SingleSelectable] for exposing non-nullable value methods.
 abstract class SingleOrNullSelectable<T> {
   /// Executes this statement, like [Selectable.get], but only returns one
   /// value. If the result too many values, this method will throw. If no
@@ -143,6 +197,14 @@ abstract class SingleOrNullSelectable<T> {
 
 /// Abstract class for queries which can return one-time values or a stream
 /// of values.
+///
+/// If you want to make your query consumable as either a [Future] or a
+/// [Stream], you can refine your return type using one of Selectable's
+/// base classes:
+///
+/// {@macro moor_multi_selectable_example}
+/// {@macro moor_single_selectable_example}
+/// {@macro moor_single_or_null_selectable_example}
 abstract class Selectable<T>
     implements
         MultiSelectable<T>,

--- a/moor/lib/src/runtime/query_builder/statements/query.dart
+++ b/moor/lib/src/runtime/query_builder/statements/query.dart
@@ -76,8 +76,9 @@ abstract class Query<T extends Table, D extends DataClass> extends Component {
 /// {@template moor_multi_selectable_example}
 /// ```dart
 /// /// Retrieve a page of [Todo]s.
-/// MultiSelectable<Todo> pageOfTodos(int page, {int pageSize = 10}) =>
-///   select(todos)..limit(pageSize, offset: page);
+/// MultiSelectable<Todo> pageOfTodos(int page, {int pageSize = 10}) {
+///   return select(todos)..limit(pageSize, offset: page);
+/// }
 /// pageOfTodos(1).get();
 /// pageOfTodos(1).watch();
 /// ```
@@ -103,8 +104,9 @@ abstract class MultiSelectable<T> {
 /// {@template moor_single_selectable_example}
 /// ```dart
 /// // Retrieve a todo known to exist.
-/// SingleSelectable<Todo> entryById(int id) =>
-///   select(todos)..where((t) => t.id.equals(id));
+/// SingleSelectable<Todo> entryById(int id) {
+///   return select(todos)..where((t) => t.id.equals(id));
+/// }
 /// final idGuaranteedToExist = 10;
 /// entryById(idGuaranteedToExist).getSingle();
 /// entryById(idGuaranteedToExist).watchSingle();
@@ -159,9 +161,9 @@ abstract class SingleSelectable<T> {
 /// {@template moor_single_or_null_selectable_example}
 ///```dart
 /// // Retrieve a todo from an external link that may not be valid.
-/// SingleOrNullSelectable<Todo> entryFromExternalLink(int id) =>
-///   select(todos)..where((t) => t.id.equals(id));
-///
+/// SingleOrNullSelectable<Todo> entryFromExternalLink(int id) {
+///   return select(todos)..where((t) => t.id.equals(id));
+/// }
 /// final idFromEmailLink = 100;
 /// entryFromExternalLink(idFromEmailLink).getSingleOrNull();
 /// entryFromExternalLink(idFromEmailLink).watchSingleOrNull();

--- a/moor/lib/src/runtime/query_builder/statements/query.dart
+++ b/moor/lib/src/runtime/query_builder/statements/query.dart
@@ -104,9 +104,8 @@ abstract class MultiSelectable<T> {
 /// {@template moor_single_selectable_example}
 /// ```dart
 /// // Retrieve a todo known to exist.
-/// SingleSelectable<Todo> entryById(int id) {
-///   return (select(todos)..where((t) => t.id.equals(id)));
-/// }
+/// SingleSelectable<Todo> entryById(int id) =>
+///   select(todos)..where((t) => t.id.equals(id));
 /// final idGuaranteedToExist = 10;
 /// entryById(idGuaranteedToExist).getSingle();
 /// entryById(idGuaranteedToExist).watchSingle();
@@ -161,12 +160,12 @@ abstract class SingleSelectable<T> {
 /// {@template moor_single_or_null_selectable_example}
 ///```dart
 /// // Retrieve a todo from an external link that may not be valid.
-/// SingleOrNullSelectable<Todo> todoFromExternalLink(int id) =>
+/// SingleOrNullSelectable<Todo> entryFromExternalLink(int id) =>
 ///   select(todos)..where((t) => t.id.equals(id));
 ///
 /// final idFromEmailLink = 100;
-/// todoFromExternalLink(idFromEmailLink).getSingleOrNull();
-/// todoFromExternalLink(idFromEmailLink).watchSingleOrNull();
+/// entryFromExternalLink(idFromEmailLink).getSingleOrNull();
+/// entryFromExternalLink(idFromEmailLink).watchSingleOrNull();
 /// ```
 /// {@endtemplate}
 ///


### PR DESCRIPTION
This makes it so users can expose more refined/foolproof apis to their application:

```dart
extension TaskMethods on Task {
  /// won't make mistakes like using getSingle when using
  SingleOrNullSelectable<CalendarEvent> get event =>
      db.calendarEvents.forTask(this);

  /// autocomplete ignores getSingle, etc
  MultiSelectable<Metric> get metrics =>
      db.metrics.forTask(this);
}
```

This is the result of continuing to explore @simolus3's suggestion in https://github.com/simolus3/moor/issues/569#issuecomment-812695152 and trying to decide between `Future` and `Stream` getters. I thought, "why not both?" and decided it would be good to have a type-refinement.

I'm not attached to the naming.

<details>
<summary>More sample usage</summary>

```dart
extension TaskMethods on Task {
  MultiSelectable<CalendarEvent> get calendarEvents =>
      db.calendarEvents.query((ces) => ces.whereTaskIs(this));

  MultiSelectable<TaskMetric> get taskMetrics =>
      db.taskMetrics.query((tms) => tms.whereTaskIs(this));
}

extension TaskMetricMethods on TaskMetric {
  // TODO can't genericize these getters due to dataclass limitations
  SingleSelectable<Metric> get metric => db.metrics.query((m) =>
      m.entityId.equals(metricEntityId) &
      m.validUntil.equals(metricValidUntil) &
      m.validUntil.equals(Validity.current));

  SingleSelectable<Task> get task => db.tasks.query((m) =>
      m.entityId.equals(taskEntityId) &
      m.validUntil.equals(taskValidUntil) &
      m.validUntil.equals(Validity.current));
}
```
</details>

Opening as a draft as RFC and because I haven't actually run my app using these changes yet