### PR TITLE
Change predicate from Expression<bool> to Expression<bool?>

### DIFF
--- a/moor_generator/lib/src/model/sql_query.dart
+++ b/moor_generator/lib/src/model/sql_query.dart
@@ -572,7 +572,7 @@ class ExpressionDartPlaceholderType extends DartPlaceholderType {
     if (columnType == null) return 'Expression';
 
     final dartType = dartTypeNames[columnType];
-    return 'Expression<$dartType>';
+    return 'Expression<${options.nullableType(dartType)}>';
   }
 }
 


### PR DESCRIPTION
```
listItems($predicate = TRUE):
SELECT *
FROM table
WHERE $predicate
```

will generate
```dart
Future<int> listItems({Expression<bool> predicate = const CustomExpression('(TRUE)')})
```

However all column expressions evaluate to Expression<bool?> which is incompatible.
I'm not sure if this is the correct solution as ExpressionDartPlaceholderType seems to be used elsewhere