### PR TITLE
from instead of fom

### DIFF
--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -11,7 +11,7 @@ path: ""
 		Learn moor <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://pub.dev/packages/moor">
-		Get fom pub <i class="fas fa-code ml-2 "></i>
+		Get from pub <i class="fas fa-code ml-2 "></i>
 	</a>
 
 	<p class="lead mt-5">


### PR DESCRIPTION
Spelling mistake of a button "Get from pub" changes