### PR TITLE
Correctly override Object.== everywhere

### DIFF
--- a/moor/lib/src/runtime/api/stream_updates.dart
+++ b/moor/lib/src/runtime/api/stream_updates.dart
@@ -100,7 +100,7 @@ class TableUpdate {
   int get hashCode => $mrjf($mrjc(kind.hashCode, table.hashCode));
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is TableUpdate && other.kind == kind && other.table == table;
   }
 

--- a/moor/lib/src/runtime/data_class.dart
+++ b/moor/lib/src/runtime/data_class.dart
@@ -69,7 +69,7 @@ abstract class UpdateCompanion<D> implements Insertable<D> {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! UpdateCompanion<D>) return false;
 

--- a/moor/lib/src/runtime/executor/executor.dart
+++ b/moor/lib/src/runtime/executor/executor.dart
@@ -100,7 +100,7 @@ class BatchedStatements {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is BatchedStatements &&
         _equality.equals(other.statements, statements) &&
         _equality.equals(other.arguments, arguments);
@@ -130,7 +130,7 @@ class ArgumentsForBatchedStatement {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is ArgumentsForBatchedStatement &&
         other.statementIndex == statementIndex &&
         _equality.equals(other.arguments, arguments);

--- a/moor/lib/src/runtime/executor/stream_queries.dart
+++ b/moor/lib/src/runtime/executor/stream_queries.dart
@@ -53,7 +53,7 @@ class StreamKey {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other is StreamKey &&
             other.sql == sql &&
@@ -311,7 +311,7 @@ class SpecificUpdateQuery extends TableUpdateQuery {
   int get hashCode => $mrjf($mrjc(limitUpdateKind.hashCode, table.hashCode));
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is SpecificUpdateQuery &&
         other.limitUpdateKind == limitUpdateKind &&
         other.table == table;

--- a/moor/lib/src/runtime/query_builder/components/where.dart
+++ b/moor/lib/src/runtime/query_builder/components/where.dart
@@ -19,7 +19,7 @@ class Where extends Component {
   int get hashCode => predicate.hashCode * 7;
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         other is Where && other.predicate == predicate;
   }

--- a/moor/lib/src/runtime/query_builder/expressions/aggregate.dart
+++ b/moor/lib/src/runtime/query_builder/expressions/aggregate.dart
@@ -136,7 +136,7 @@ class _AggregateExpression<D> extends Expression<D> {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (!identical(this, other) && other.runtimeType != runtimeType) {
       return false;
     }

--- a/moor/lib/src/runtime/query_builder/expressions/bools.dart
+++ b/moor/lib/src/runtime/query_builder/expressions/bools.dart
@@ -35,7 +35,7 @@ class _NotExpression extends Expression<bool?> {
   int get hashCode => inner.hashCode << 1;
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is _NotExpression && other.inner == inner;
   }
 }

--- a/moor/lib/src/runtime/query_builder/expressions/comparable.dart
+++ b/moor/lib/src/runtime/query_builder/expressions/comparable.dart
@@ -110,7 +110,7 @@ class _BetweenExpression extends Expression<bool?> {
       $mrjc(lower.hashCode, $mrjc(higher.hashCode, not.hashCode))));
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is _BetweenExpression &&
         other.target == target &&
         other.not == not &&

--- a/moor/lib/src/runtime/query_builder/expressions/custom.dart
+++ b/moor/lib/src/runtime/query_builder/expressions/custom.dart
@@ -36,7 +36,7 @@ class CustomExpression<D> extends Expression<D> {
   int get hashCode => content.hashCode * 3;
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other.runtimeType == runtimeType &&
         // ignore: test_types_in_equals
         (other as CustomExpression).content == content;

--- a/moor/lib/src/runtime/query_builder/expressions/datetimes.dart
+++ b/moor/lib/src/runtime/query_builder/expressions/datetimes.dart
@@ -85,7 +85,7 @@ class _StrftimeSingleFieldExpression extends Expression<int?> {
   int get hashCode => $mrjf($mrjc(format.hashCode, date.hashCode));
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is _StrftimeSingleFieldExpression &&
         other.format == format &&
         other.date == date;

--- a/moor/lib/src/runtime/query_builder/expressions/exists.dart
+++ b/moor/lib/src/runtime/query_builder/expressions/exists.dart
@@ -36,7 +36,7 @@ class _ExistsExpression<T> extends Expression<bool> {
   int get hashCode => $mrjf($mrjc(_select.hashCode, _not.hashCode));
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is _ExistsExpression &&
         other._select == _select &&
         other._not == _not;

--- a/moor/lib/src/runtime/query_builder/expressions/expression.dart
+++ b/moor/lib/src/runtime/query_builder/expressions/expression.dart
@@ -174,7 +174,7 @@ class Precedence implements Comparable<Precedence> {
   int get hashCode => _value;
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     // runtimeType comparison isn't necessary, the private constructor prevents
     // subclasses
     return other is Precedence && other._value == _value;
@@ -257,7 +257,7 @@ abstract class _InfixOperator<D> extends Expression<D> {
       $mrjf($mrjc(left.hashCode, $mrjc(right.hashCode, operator.hashCode)));
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is _InfixOperator &&
         other.left == left &&
         other.right == right &&
@@ -357,7 +357,7 @@ class _UnaryMinus<DT> extends Expression<DT> {
   int get hashCode => inner.hashCode * 5;
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is _UnaryMinus && other.inner == inner;
   }
 }
@@ -382,7 +382,7 @@ class _DartCastExpression<D1, D2> extends Expression<D2> {
   int get hashCode => inner.hashCode * 7;
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is _DartCastExpression && other.inner == inner;
   }
 }
@@ -436,7 +436,7 @@ class FunctionCallExpression<R> extends Expression<R> {
       $mrjf($mrjc(functionName.hashCode, _equality.hash(arguments)));
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is FunctionCallExpression &&
         other.functionName == functionName &&
         _equality.equals(other.arguments, arguments);

--- a/moor/lib/src/runtime/query_builder/expressions/in.dart
+++ b/moor/lib/src/runtime/query_builder/expressions/in.dart
@@ -52,7 +52,7 @@ class _InExpression<T> extends _BaseInExpression {
       _expression.hashCode, $mrjc(_equality.hash(_values), _not.hashCode)));
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is _InExpression &&
         other._expression == _expression &&
         _equality.equals(other._values, _values) &&
@@ -76,7 +76,7 @@ class _InSelectExpression extends _BaseInExpression {
       $mrjc(_expression.hashCode, $mrjc(_select.hashCode, _not.hashCode)));
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is _InSelectExpression &&
         other._expression == _expression &&
         other._select == _select &&

--- a/moor/lib/src/runtime/query_builder/expressions/null_check.dart
+++ b/moor/lib/src/runtime/query_builder/expressions/null_check.dart
@@ -53,7 +53,7 @@ class _NullCheck extends Expression<bool> {
   int get hashCode => $mrjf($mrjc(_inner.hashCode, _isNull.hashCode));
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is _NullCheck &&
         other._inner == _inner &&
         other._isNull == _isNull;

--- a/moor/lib/src/runtime/query_builder/expressions/text.dart
+++ b/moor/lib/src/runtime/query_builder/expressions/text.dart
@@ -154,7 +154,7 @@ class _LikeOperator extends Expression<bool?> {
       $mrjf($mrjc(target.hashCode, $mrjc(regex.hashCode, operator.hashCode)));
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is _LikeOperator &&
         other.target == target &&
         other.regex == regex &&
@@ -208,7 +208,7 @@ class _CollateOperator extends Expression<String> {
   int get hashCode => $mrjf($mrjc(inner.hashCode, collate.hashCode));
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is _CollateOperator &&
         other.inner == inner &&
         other.collate == collate;

--- a/moor/lib/src/runtime/query_builder/expressions/variables.dart
+++ b/moor/lib/src/runtime/query_builder/expressions/variables.dart
@@ -72,7 +72,7 @@ class Variable<T> extends Expression<T> {
   String toString() => 'Variable($value)';
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other is Variable && other.value == value;
   }
 }
@@ -102,7 +102,7 @@ class Constant<T> extends Expression<T> {
   int get hashCode => value.hashCode;
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return other.runtimeType == runtimeType &&
         // ignore: test_types_in_equals
         (other as Constant<T>).value == value;

--- a/moor/lib/src/runtime/query_builder/schema/column_impl.dart
+++ b/moor/lib/src/runtime/query_builder/schema/column_impl.dart
@@ -166,7 +166,7 @@ class GeneratedColumn<T> extends Column<T> {
   int get hashCode => $mrjf($mrjc(tableName.hashCode, $name.hashCode));
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (other.runtimeType != runtimeType) return false;
 
     // ignore: test_types_in_equals

--- a/moor/lib/src/runtime/query_builder/schema/table_info.dart
+++ b/moor/lib/src/runtime/query_builder/schema/table_info.dart
@@ -77,7 +77,7 @@ mixin TableInfo<TableDsl extends Table, D> on Table
   TableInfo<TableDsl, D> createAlias(String alias);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     // tables are singleton instances except for aliases
     if (other is TableInfo) {
       return other.runtimeType == runtimeType && other.$tableName == $tableName;

--- a/moor_generator/lib/src/analyzer/runner/file_graph.dart
+++ b/moor_generator/lib/src/analyzer/runner/file_graph.dart
@@ -123,7 +123,7 @@ class FoundFile {
   int get hashCode => uri.hashCode;
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) || other is FoundFile && other.uri == uri;
   }
 

--- a/moor_generator/lib/src/model/column.dart
+++ b/moor_generator/lib/src/model/column.dart
@@ -27,7 +27,7 @@ class ColumnName {
   int get hashCode => name.hashCode + implicit.hashCode * 31;
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (other.runtimeType != runtimeType) return false;
     // ignore: test_types_in_equals
     final typedOther = other as ColumnName;
@@ -199,7 +199,7 @@ class AutoIncrement extends PrimaryKey {
   factory AutoIncrement() => _instance;
 
   @override
-  bool operator ==(dynamic other) => other is AutoIncrement;
+  bool operator ==(Object other) => other is AutoIncrement;
 
   @override
   int get hashCode => 1337420;
@@ -216,7 +216,7 @@ class LimitingTextLength extends ColumnFeature {
   int get hashCode => minLength.hashCode ^ maxLength.hashCode;
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (other.runtimeType != runtimeType) return false;
     // ignore: test_types_in_equals
     final typedOther = other as LimitingTextLength;

--- a/moor_generator/lib/src/model/sql_query.dart
+++ b/moor_generator/lib/src/model/sql_query.dart
@@ -652,7 +652,7 @@ class FoundDartPlaceholder extends FoundElement {
   int get hashCode => hashAll([type, name, ...availableResultSets]);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         other is FoundDartPlaceholder &&
             other.type == type &&


### PR DESCRIPTION
Using dynamic results in invalid mocks being generated by mockito since `==(dynamic other)` can not be overridden by `==(Object other)`.