### PR TITLE
Mark _ensureOpenCalled before migrations.

### DIFF
--- a/moor/lib/src/runtime/executor/helpers/engines.dart
+++ b/moor/lib/src/runtime/executor/helpers/engines.dart
@@ -264,8 +264,8 @@ class DelegatedDatabase extends QueryExecutor with _ExecutorWithQueryDelegate {
       }
 
       await delegate.open(user);
-      await _runMigrations(user);
       _ensureOpenCalled = true;
+      await _runMigrations(user);
       return true;
     });
   }


### PR DESCRIPTION
It looks like we should mark _ensureOpenCalled before migrations, otherwise, it's not possible to run queries during migrations?
