### PR TITLE
Prevent NullAwareTypeConverter dart value from being null

### DIFF
--- a/moor/lib/src/runtime/types/custom_type.dart
+++ b/moor/lib/src/runtime/types/custom_type.dart
@@ -51,7 +51,8 @@ class EnumIndexConverter<T> extends NullAwareTypeConverter<T, int> {
 ///
 /// Apart from the implementation changes, subclasses of this converter can be
 /// used just like all other type converters.
-abstract class NullAwareTypeConverter<D, S> extends TypeConverter<D, S> {
+abstract class NullAwareTypeConverter<D, S extends Object>
+    extends TypeConverter<D, S> {
   /// Constant default constructor.
   const NullAwareTypeConverter();
 


### PR DESCRIPTION
It is currently possible to pass null types to `NullAwareTypeConverter`
```
class MyTypeConverter extends NullAwareTypeConverter<String, String?> {
  String requireMapToDart(String? value);
  String? requireMapToSql(String value);
}
```

Because `NullAwareTypeConverter` handles nulls, a null will never get to `requireMapToDart` and the user may incorrectly try to handle that themselves.

This PR makes the dart value in `NullAwareTypeConverter` extend `Object` preventing it from being nullable and enforcing that behaviour.