### PR TITLE
Add null aware type converter option

### DIFF
--- a/docs/pages/docs/Advanced Features/builder_options.md
+++ b/docs/pages/docs/Advanced Features/builder_options.md
@@ -80,6 +80,7 @@ At the moment, drift supports these options:
 * `scoped_dart_components`: Generates a function parameter for [Dart placeholders]({{ '../Using SQL/moor_files.md#dart-components-in-sql' | pageUrl }}) in SQL.
   The function has a parameter for each table that is available in the query, making it easier to get aliases right when using
   Dart placeholders.
+* `null_aware_type_converters`: Consider the type of applied type converters to determine nullability of columns in Dart.
 
 ## Assumed SQL environment
 

--- a/drift_dev/lib/src/analyzer/dart/table_parser.dart
+++ b/drift_dev/lib/src/analyzer/dart/table_parser.dart
@@ -99,7 +99,7 @@ class TableParser {
     final verified = existingClass == null
         ? null
         : validateExistingClass(columns, existingClass,
-            constructorInExistingClass!, generateInsertable!, base.step.errors);
+            constructorInExistingClass!, generateInsertable!, base.step);
     return _DataClassInformation(name, verified);
   }
 

--- a/drift_dev/lib/src/analyzer/moor/create_table_reader.dart
+++ b/drift_dev/lib/src/analyzer/moor/create_table_reader.dart
@@ -183,7 +183,7 @@ class CreateTableReader {
           ));
         } else {
           existingRowClass = validateExistingClass(
-              foundColumns.values, clazz, '', false, step.errors);
+              foundColumns.values, clazz, '', false, step);
           dataClassName = existingRowClass?.targetClass.name;
         }
       } else if (overriddenNames.contains('/')) {

--- a/drift_dev/lib/src/analyzer/options.dart
+++ b/drift_dev/lib/src/analyzer/options.dart
@@ -101,6 +101,9 @@ class MoorOptions {
   @JsonKey(name: 'scoped_dart_components', defaultValue: false)
   final bool scopedDartComponents;
 
+  @JsonKey(name: 'null_aware_type_converters', defaultValue: false)
+  final bool nullAwareTypeConverters;
+
   @internal
   const MoorOptions.defaults({
     this.generateFromJsonStringConstructor = false,
@@ -123,6 +126,7 @@ class MoorOptions {
     this.modules = const [],
     this.sqliteAnalysisOptions,
     this.dialect = const DialectOptions(SqlDialect.sqlite, null),
+    this.nullAwareTypeConverters = false,
   });
 
   MoorOptions({
@@ -145,6 +149,7 @@ class MoorOptions {
     required this.scopedDartComponents,
     required this.modules,
     required this.sqliteAnalysisOptions,
+    required this.nullAwareTypeConverters,
     this.dialect,
   }) {
     if (sqliteAnalysisOptions != null && modules.isNotEmpty) {

--- a/drift_dev/lib/src/analyzer/options.g.dart
+++ b/drift_dev/lib/src/analyzer/options.g.dart
@@ -32,7 +32,8 @@ MoorOptions _$MoorOptionsFromJson(Map json) => $checkedCreate(
             'named_parameters',
             'named_parameters_always_required',
             'new_sql_code_generation',
-            'scoped_dart_components'
+            'scoped_dart_components',
+            'null_aware_type_converters',
           ],
         );
         final val = MoorOptions(
@@ -85,6 +86,8 @@ MoorOptions _$MoorOptionsFromJson(Map json) => $checkedCreate(
                   v == null ? null : SqliteAnalysisOptions.fromJson(v as Map)),
           dialect: $checkedConvert('sql',
               (v) => v == null ? null : DialectOptions.fromJson(v as Map)),
+          nullAwareTypeConverters: $checkedConvert(
+              'null_aware_type_converters', (v) => v as bool? ?? false),
         );
         return val;
       },
@@ -108,6 +111,7 @@ MoorOptions _$MoorOptionsFromJson(Map json) => $checkedCreate(
         'generateNamedParameters': 'named_parameters',
         'namedParametersAlwaysRequired': 'named_parameters_always_required',
         'newSqlCodeGeneration': 'new_sql_code_generation',
+        'nullAwareTypeConverters': 'null_aware_type_converters',
         'scopedDartComponents': 'scoped_dart_components',
         'modules': 'sqlite_modules',
         'sqliteAnalysisOptions': 'sqlite',

--- a/drift_dev/lib/src/analyzer/view/view_analyzer.dart
+++ b/drift_dev/lib/src/analyzer/view/view_analyzer.dart
@@ -64,7 +64,7 @@ class ViewAnalyzer extends BaseAnalyzer {
             ));
           } else {
             final rowClass = view.existingRowClass =
-                validateExistingClass(columns, clazz, '', false, step.errors);
+                validateExistingClass(columns, clazz, '', false, step);
             final newName = rowClass?.targetClass.name;
             if (newName != null) {
               view.dartTypeName = rowClass!.targetClass.name;

--- a/drift_dev/lib/src/backends/build/moor_builder.dart
+++ b/drift_dev/lib/src/backends/build/moor_builder.dart
@@ -23,7 +23,9 @@ mixin MoorBuilder on Builder {
   Writer createWriter({bool nnbd = false}) {
     return Writer(options,
         generationOptions: GenerationOptions(
-            nnbd: nnbd, writeForMoorPackage: !isForNewDriftPackage));
+            nnbd: nnbd,
+            writeForMoorPackage: !isForNewDriftPackage,
+            nullAwareTypeConverters: options.nullAwareTypeConverters));
   }
 
   Future<ParsedDartFile> analyzeDartFile(BuildStep step) async {

--- a/drift_dev/lib/src/cli/commands/schema/generate_utils.dart
+++ b/drift_dev/lib/src/cli/commands/schema/generate_utils.dart
@@ -153,6 +153,8 @@ class GenerateUtilsCommand extends Command {
         writeCompanions: companions,
         writeDataClasses: dataClasses,
         writeForMoorPackage: isForMoor,
+        nullAwareTypeConverters:
+            cli.project.moorOptions.nullAwareTypeConverters,
       ),
     );
     final file = File(p.join(output.path, _filenameForVersion(version)));

--- a/drift_dev/lib/src/model/types.dart
+++ b/drift_dev/lib/src/model/types.dart
@@ -60,8 +60,10 @@ extension OperationOnTypes on HasType {
   String dartTypeCode([GenerationOptions options = const GenerationOptions()]) {
     final converter = typeConverter;
     if (converter != null) {
-      final needsSuffix =
-          options.nnbd && nullable && !converter.hasNullableDartType;
+      final needsSuffix = options.nnbd &&
+          (options.nullAwareTypeConverters
+              ? converter.hasNullableDartType
+              : (nullable && !converter.hasNullableDartType));
       final baseType = converter.mappedType.codeString(options);
 
       final inner = needsSuffix ? '$baseType?' : baseType;

--- a/drift_dev/lib/src/writer/tables/table_writer.dart
+++ b/drift_dev/lib/src/writer/tables/table_writer.dart
@@ -198,6 +198,7 @@ abstract class TableOrViewWriter {
         named,
         tableOrView,
         scope.generationOptions,
+        scope.options,
       );
 
       final classElement = info.targetClass;

--- a/drift_dev/lib/src/writer/writer.dart
+++ b/drift_dev/lib/src/writer/writer.dart
@@ -121,12 +121,15 @@ class GenerationOptions {
   /// new `drift` package.
   final bool writeForMoorPackage;
 
+  final bool nullAwareTypeConverters;
+
   const GenerationOptions({
     this.forSchema,
     this.nnbd = false,
     this.writeDataClasses = true,
     this.writeCompanions = true,
     this.writeForMoorPackage = false,
+    this.nullAwareTypeConverters = false,
   });
 
   /// Whether, instead of generating the full database code, we're only


### PR DESCRIPTION
This option let TypeConverter to determinate Dart type nullability.

When you use @UseRowClass without enable 'null_aware_type_converters' this code throws `Expected this parameter to be nullable` error. Using nullable column Drift expects nullable dart type in row class, even if TypeConverter returns non-nullable type.

If you let Drift generates DataClass (default) the generated field will be nullable even if TypeConverter returns non-nullable type. 

This helps wrapping nullable columns in non-nullable type

```dart
TextColumn get customer => text()
    .named('customerId')
    .nullable()
    .references(PartnerTable, #id)
    .map(const RefConv<Partner?>())();

DataClass {
    final Ref<Partner?> customer;
}

class RefConv<T extends BaseModel?> extends TypeConverter<Ref<T>, String> {
  const RefConv();

  @override
  Ref<T>? mapToDart(String? fromDb) {
    return Ref<T>.id(fromDb);
  }

  @override
  String? mapToSql(Ref<T>? value) {
    return value?.id;
  }
}
```
