### PR TITLE
Check references only on Database

### DIFF
--- a/drift_dev/lib/src/analyzer/runner/steps/analyze_dart.dart
+++ b/drift_dev/lib/src/analyzer/runner/steps/analyze_dart.dart
@@ -34,7 +34,10 @@ class AnalyzeDartStep extends AnalyzingStep {
           tableDartClasses[declaration.element] = declaredHere;
         }
       }
-      _resolveDartColumnReferences(tableDartClasses);
+
+      if (accessor is Database) {
+        _resolveDartColumnReferences(tableDartClasses);
+      }
 
       List<MoorSchemaEntity>? availableEntities;
 


### PR DESCRIPTION
Using `@DriftAccessor(tables: [Companies])` Drift throws error when tables not included in the list that provided table references. This isn't necessary for Dao
```
 This class has not been added as a table
   ╷
28 │       .references(Addresses, #id)
   │                   ^^^^^^^^^
   ╵

```