### PR TITLE
Fix virtual table test

### DIFF
--- a/drift_dev/test/analyzer/moor/virtual_table_test.dart
+++ b/drift_dev/test/analyzer/moor/virtual_table_test.dart
@@ -1,4 +1,5 @@
 import 'package:drift_dev/src/analyzer/options.dart';
+import 'package:test/scaffolding.dart';
 import 'package:test/test.dart';
 
 import '../utils.dart';
@@ -20,6 +21,7 @@ CREATE VIRTUAL TABLE example_table_search
     );
 ''',
         'a|lib/queries.moor': '''
+import 'table.moor';
 
 exampleSearch: SELECT example_table.**, s.* FROM example_table
     INNER JOIN (

--- a/drift_dev/test/analyzer/moor/virtual_table_test.dart
+++ b/drift_dev/test/analyzer/moor/virtual_table_test.dart
@@ -1,5 +1,4 @@
 import 'package:drift_dev/src/analyzer/options.dart';
-import 'package:test/scaffolding.dart';
 import 'package:test/test.dart';
 
 import '../utils.dart';

--- a/drift_dev/test/analyzer/moor/virtual_table_test.dart
+++ b/drift_dev/test/analyzer/moor/virtual_table_test.dart
@@ -43,7 +43,7 @@ exampleSearch: SELECT example_table.**, s.* FROM example_table
     expect(result.errors.errors, isEmpty);
   });
 
-  test('query virtual tables with unknown fucntion', () async {
+  test('query virtual tables with unknown function', () async {
     final state = TestState.withContent(
       {
         'a|lib/table.moor': '''


### PR DESCRIPTION
After boyan's new `query virtual tables with unknown function` test case the `supports virtual tables across moor files` case went broken. Import missing from SQL code. Maybe his import optimiser deleted the import from string literal too. 