### PR TITLE
Fix broken iterable comparison in sqlparser

### DIFF
--- a/drift/lib/src/runtime/data_class.dart
+++ b/drift/lib/src/runtime/data_class.dart
@@ -158,7 +158,7 @@ class Value<T> {
   const Value.ofNullable(T? value)
       : assert(
           value != null || null is! T,
-          "Value.absentIfNull(null) can't be used for a nullable T, since the "
+          "Value.ofNullable(null) can't be used for a nullable T, since the "
           'null value could be both absent and present.',
         ),
         _value = value,

--- a/sqlparser/lib/src/utils/ast_equality.dart
+++ b/sqlparser/lib/src/utils/ast_equality.dart
@@ -10,12 +10,17 @@ void enforceEqualIterable(Iterable<AstNode> a, Iterable<AstNode> b) {
   final childrenA = a.iterator;
   final childrenB = b.iterator;
 
+  var movedA = false;
+  var movedB = false;
+
   // always move both iterators
-  while (childrenA.moveNext() & childrenB.moveNext()) {
+  // need to store the result so it can be compared afterwards
+  // since it does not get reverted if only one moved
+  while ((movedA = childrenA.moveNext()) & (movedB = childrenB.moveNext())) {
     enforceEqual(childrenA.current, childrenB.current);
   }
 
-  if (childrenA.moveNext() || childrenB.moveNext()) {
+  if (movedA || movedB) {
     throw ArgumentError("$a and $b don't have an equal amount of children");
   }
 }

--- a/sqlparser/test/utils/ast_quality_test.dart
+++ b/sqlparser/test/utils/ast_quality_test.dart
@@ -1,0 +1,73 @@
+import 'package:sqlparser/sqlparser.dart';
+import 'package:sqlparser/src/utils/ast_equality.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  group(enforceEqualIterable, () {
+    test('should accept 2 equal iterables', () {
+      enforceEqualIterable(
+        [
+          NotNull('foo'),
+        ],
+        [
+          NotNull('foo'),
+        ],
+      );
+    });
+
+    test('should throw if only first is empty', () {
+      expect(
+        () => enforceEqualIterable(
+          [],
+          [
+            NotNull('foo'),
+          ],
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should throw if only second is empty', () {
+      expect(
+        () => enforceEqualIterable(
+          [
+            NotNull('foo'),
+          ],
+          [],
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should throw if first is shorter', () {
+      expect(
+        () => enforceEqualIterable(
+          [
+            NotNull('foo'),
+          ],
+          [
+            NotNull('foo'),
+            UniqueColumn('foo', null),
+          ],
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should throw if second is shorter', () {
+      expect(
+        () => enforceEqualIterable(
+          [
+            NotNull('foo'),
+            UniqueColumn('foo', null),
+          ],
+          [
+            NotNull('foo'),
+          ],
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
* this results in false positive migration tests, not sure what else could be effected

Hi @simolus3, maybe you can release a hotfix for this, really need this to work :)