### PR TITLE
Fix ViewParser not support alias column

### DIFF
--- a/drift_dev/lib/src/analyzer/dart/view_parser.dart
+++ b/drift_dev/lib/src/analyzer/dart/view_parser.dart
@@ -107,7 +107,7 @@ class ViewParser {
         .followedBy([element])
         .expand((e) => e.fields)
         .where((field) =>
-            isExpression(field.type) &&
+            (isExpression(field.type) || isColumn(field.type)) &&
             field.getter != null &&
             !field.getter!.isSynthetic)
         .map((field) => field.name)


### PR DESCRIPTION
fix #1583 

Currently DSL Views does not support columns defined by `get`, for example:

```dart
abstract class RecordViews extends View {
  Tasks get tasks;

  Categories get categories;

  Records get records;

  IntColumn get taskId => tasks.sid;

  Expression<int> get itemCount => records.sid.count();

  @override
  Query<HasResultSet, dynamic> as() => select([
    taskId,
    itemCount,
      ]).from(records).join([
        leftOuterJoin(tasks, tasks.sid.equalsExp(records.taskId)),
      ]);
}
```

However, it is necessary to provide renaming support for the columns in the View in this way.