### PR TITLE
Move serialization decision from server to client

### DIFF
--- a/drift/test/isolate_test.dart
+++ b/drift/test/isolate_test.dart
@@ -116,8 +116,7 @@ void _runTests(FutureOr<DriftIsolate> Function() spawner, bool terminateIsolate,
     isolate = await spawner();
 
     database = TodoDb.connect(
-      DatabaseConnection.delayed(
-          isolate.connect(isolateDebugLog: false, serialize: serialize)),
+      DatabaseConnection.delayed(isolate.connect()),
     );
   });
 
@@ -125,7 +124,7 @@ void _runTests(FutureOr<DriftIsolate> Function() spawner, bool terminateIsolate,
     await database.close();
 
     if (terminateIsolate) {
-      await isolate.shutdownAll(serialize: serialize);
+      await isolate.shutdownAll();
     }
   });
 


### PR DESCRIPTION
Enable the `DriftServer` to handle connections from clients independent of their serialization configuration.

Fixes #1593