### PR TITLE
Move rxdart tests into separate files

### DIFF
--- a/drift/test/integration_tests/cancellation_test.dart
+++ b/drift/test/integration_tests/cancellation_test.dart
@@ -1,50 +1,9 @@
 @Tags(['integration'])
 import 'package:drift/drift.dart';
 import 'package:drift/isolate.dart';
-import 'package:drift/native.dart';
-import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
-DatabaseConnection createConnection() {
-  var counter = 0;
-  final loggedValues = <int>[];
-
-  return DatabaseConnection.fromExecutor(
-    NativeDatabase.memory(
-      setup: (rawDb) {
-        rawDb.createFunction(
-          functionName: 'increment_counter',
-          function: (args) => counter++,
-        );
-        rawDb.createFunction(
-          functionName: 'get_counter',
-          function: (args) => counter,
-        );
-
-        rawDb.createFunction(
-          functionName: 'log_value',
-          function: (args) {
-            final value = args.single as int;
-            loggedValues.add(value);
-            return value;
-          },
-        );
-        rawDb.createFunction(
-          functionName: 'get_values',
-          function: (args) => loggedValues.join(','),
-        );
-      },
-    ),
-  );
-}
-
-class EmptyDb extends GeneratedDatabase {
-  EmptyDb.connect(DatabaseConnection c) : super.connect(c);
-  @override
-  final List<TableInfo> allTables = const [];
-  @override
-  final int schemaVersion = 1;
-}
+import 'cancellation_test_support.dart';
 
 void main() {
   driftRuntimeOptions.dontWarnAboutMultipleDatabases = true;
@@ -84,35 +43,4 @@ void main() {
       await runTest(db);
     });
   }, skip: 'todo: Cancellations are currently broken on Dart 2.15');
-
-  test('together with switchMap', () async {
-    String slowQuery(int i) => '''
-      with recursive slow(x) as (values(log_value($i)) union all select x+1 from slow where x < 1000000)
-      select $i from slow;
-    ''';
-
-    final isolate = await DriftIsolate.spawn(createConnection);
-    addTearDown(isolate.shutdownAll);
-
-    final db = EmptyDb.connect(await isolate.connect());
-    await db.customSelect('select 1').getSingle();
-
-    final filter = BehaviorSubject<int>();
-    addTearDown(filter.close);
-    filter
-        .switchMap((value) => db.customSelect(slowQuery(value)).watch())
-        .listen(null);
-
-    for (var i = 0; i < 4; i++) {
-      filter.add(i);
-      await pumpEventQueue();
-    }
-
-    final values = await db
-        .customSelect('select get_values() r')
-        .map((row) => row.read<String>('r'))
-        .getSingle();
-
-    expect(values.split(',').length, lessThan(4), reason: 'Read all $values');
-  });
 }

--- a/drift/test/integration_tests/cancellation_test_support.dart
+++ b/drift/test/integration_tests/cancellation_test_support.dart
@@ -1,0 +1,43 @@
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+
+DatabaseConnection createConnection() {
+  var counter = 0;
+  final loggedValues = <int>[];
+
+  return DatabaseConnection.fromExecutor(
+    NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.createFunction(
+          functionName: 'increment_counter',
+          function: (args) => counter++,
+        );
+        rawDb.createFunction(
+          functionName: 'get_counter',
+          function: (args) => counter,
+        );
+
+        rawDb.createFunction(
+          functionName: 'log_value',
+          function: (args) {
+            final value = args.single as int;
+            loggedValues.add(value);
+            return value;
+          },
+        );
+        rawDb.createFunction(
+          functionName: 'get_values',
+          function: (args) => loggedValues.join(','),
+        );
+      },
+    ),
+  );
+}
+
+class EmptyDb extends GeneratedDatabase {
+  EmptyDb.connect(DatabaseConnection c) : super.connect(c);
+  @override
+  final List<TableInfo> allTables = const [];
+  @override
+  final int schemaVersion = 1;
+}

--- a/drift/test/integration_tests/rx_cancellation_test.dart
+++ b/drift/test/integration_tests/rx_cancellation_test.dart
@@ -1,0 +1,39 @@
+@Tags(['integration'])
+import 'package:drift/isolate.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+
+import 'cancellation_test_support.dart';
+
+void main() {
+  test('together with switchMap', () async {
+    String slowQuery(int i) => '''
+      with recursive slow(x) as (values(log_value($i)) union all select x+1 from slow where x < 1000000)
+      select $i from slow;
+    ''';
+
+    final isolate = await DriftIsolate.spawn(createConnection);
+    addTearDown(isolate.shutdownAll);
+
+    final db = EmptyDb.connect(await isolate.connect());
+    await db.customSelect('select 1').getSingle();
+
+    final filter = BehaviorSubject<int>();
+    addTearDown(filter.close);
+    filter
+        .switchMap((value) => db.customSelect(slowQuery(value)).watch())
+        .listen(null);
+
+    for (var i = 0; i < 4; i++) {
+      filter.add(i);
+      await pumpEventQueue();
+    }
+
+    final values = await db
+        .customSelect('select get_values() r')
+        .map((row) => row.read<String>('r'))
+        .getSingle();
+
+    expect(values.split(',').length, lessThan(4), reason: 'Read all $values');
+  });
+}

--- a/drift/test/rx_streams_test.dart
+++ b/drift/test/rx_streams_test.dart
@@ -1,0 +1,42 @@
+import 'package:mockito/mockito.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:test/test.dart';
+
+import 'data/tables/todos.dart';
+import 'data/utils/mocks.dart';
+
+void main() {
+  late TodoDb db;
+  late MockExecutor executor;
+  setUp(() {
+    executor = MockExecutor();
+    db = TodoDb(executor);
+  });
+
+  test('drift streams can be used with switchMap in rxdart', () async {
+    // Regression test for https://github.com/simolus3/moor/issues/500
+    when(executor.runSelect(any, any)).thenAnswer((i) async {
+      final sql = i.positionalArguments.first as String;
+
+      return [
+        if (sql.contains("'a'")) {'a': 'a'} else {'b': 'b'}
+      ];
+    });
+
+    final a = db
+        .customSelect("select 'a' as a")
+        .map(($) => $.readString('a'))
+        .watchSingle();
+    final b = db
+        .customSelect("select 'b' as b")
+        .map(($) => $.readString('b'))
+        .watchSingle();
+    final c = a.switchMap((_) => b);
+    expect(await a.first, 'a');
+    expect(await a.first, 'a');
+    expect(await b.first, 'b');
+    expect(await b.first, 'b');
+    expect(await c.first, 'b');
+    expect(await c.first, 'b');
+  });
+}

--- a/drift/test/streams_test.dart
+++ b/drift/test/streams_test.dart
@@ -4,7 +4,6 @@ import 'package:drift/drift.dart';
 import 'package:drift/src/runtime/api/runtime_api.dart';
 import 'package:drift/src/runtime/executor/stream_queries.dart';
 import 'package:mockito/mockito.dart';
-import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 import 'data/tables/custom_tables.dart';
@@ -423,32 +422,5 @@ void main() {
   test('stream queries are broadcasts', () {
     expect(db.customSelect('SELECT 1').watch().isBroadcast, isTrue);
     expect(db.customSelect('SELECT 1').watchSingle().isBroadcast, isTrue);
-  });
-
-  test('drift streams can be used with switchMap in rxdart', () async {
-    // Regression test for https://github.com/simolus3/moor/issues/500
-    when(executor.runSelect(any, any)).thenAnswer((i) async {
-      final sql = i.positionalArguments.first as String;
-
-      return [
-        if (sql.contains("'a'")) {'a': 'a'} else {'b': 'b'}
-      ];
-    });
-
-    final a = db
-        .customSelect("select 'a' as a")
-        .map(($) => $.readString('a'))
-        .watchSingle();
-    final b = db
-        .customSelect("select 'b' as b")
-        .map(($) => $.readString('b'))
-        .watchSingle();
-    final c = a.switchMap((_) => b);
-    expect(await a.first, 'a');
-    expect(await a.first, 'a');
-    expect(await b.first, 'b');
-    expect(await b.first, 'b');
-    expect(await c.first, 'b');
-    expect(await c.first, 'b');
   });
 }


### PR DESCRIPTION
Moves rxdart-specific tests into separate files. This makes it easier to exclude these tests from the test suite in environments that don't support rxdart.