### PR TITLE
Sqlparser accepts AS in delete statement

### DIFF
--- a/sqlparser/lib/src/reader/parser.dart
+++ b/sqlparser/lib/src/reader/parser.dart
@@ -1565,7 +1565,7 @@ class Parser {
 
     _consume(TokenType.from, 'Expected a FROM here');
 
-    final table = _tableReference();
+    final table = _tableReference(allowAlias: false);
 
     final where = _whereOrNull();
     final returning = _returningOrNull();


### PR DESCRIPTION
The Sqlparser accepts AS in delete statements, like the following: 
```sql
DELETE FROM tbl AS t;
```
