### PR TITLE
Improve migration guidelines

### DIFF
--- a/docs/pages/docs/Advanced Features/migrations.md
+++ b/docs/pages/docs/Advanced Features/migrations.md
@@ -18,7 +18,8 @@ class Todos extends Table {
   TextColumn get title => text().withLength(min: 6, max: 10)();
   TextColumn get content => text().named('body')();
   IntColumn get category => integer().nullable()();
-  DateTimeColumn get dueDate => dateTime().nullable()(); // new, added column
+  DateTimeColumn get dueDate => dateTime().nullable()(); // new, added column in v2
+  IntColumn get priority => integer().nullable()(); // new, added column in v3
 }
 ```
 
@@ -26,7 +27,7 @@ We can now change the `database` class like this:
 
 ```dart
   @override
-  int get schemaVersion => 2; // bump because the tables have changed
+  int get schemaVersion => 3; // bump because the tables have changed
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -34,9 +35,13 @@ We can now change the `database` class like this:
       return m.createAll();
     },
     onUpgrade: (Migrator m, int from, int to) async {
-      if (from == 1) {
+      if (from < 2) {
         // we added the dueDate property in the change from version 1
         await m.addColumn(todos, todos.dueDate);
+      }
+      if (from < 3) {
+        // we added the priority property in the change from version 2
+        await m.addColumn(todos, todos.priority);
       }
     }
   );

--- a/docs/pages/docs/Advanced Features/migrations.md
+++ b/docs/pages/docs/Advanced Features/migrations.md
@@ -36,11 +36,11 @@ We can now change the `database` class like this:
     },
     onUpgrade: (Migrator m, int from, int to) async {
       if (from < 2) {
-        // we added the dueDate property in the change from version 1
+        // we added the dueDate property in the change from version 1 to version 2
         await m.addColumn(todos, todos.dueDate);
       }
       if (from < 3) {
-        // we added the priority property in the change from version 2
+        // we added the priority property in the change from versions 1 or 2 to version 3
         await m.addColumn(todos, todos.priority);
       }
     }

--- a/docs/pages/docs/Advanced Features/migrations.md
+++ b/docs/pages/docs/Advanced Features/migrations.md
@@ -40,7 +40,7 @@ We can now change the `database` class like this:
         await m.addColumn(todos, todos.dueDate);
       }
       if (from < 3) {
-        // we added the priority property in the change from versions 1 or 2 to version 3
+        // we added the priority property in the change from version 1 or 2 to version 3
         await m.addColumn(todos, todos.priority);
       }
     }


### PR DESCRIPTION
The migration docs using `if (from == 1)` mislead me to think skipping versions would still run intermediate migrations. However, if a user goes straight from v1 to v3, the migration process won't be `1 -> 2` + `2 -> 3` as I thought, but `1 -> 3` directly, thus the code in `if (from == 2)` would never run, skipping a necessary migration.

I think the proposed change might prevent others from making the same mistake as I did.


PS: Thanks heaps for this lib, it's awesome.