### PR TITLE
change name of the update method to avoid confusion

### DIFF
--- a/docs/pages/docs/Getting started/writing_queries.md
+++ b/docs/pages/docs/Getting started/writing_queries.md
@@ -137,7 +137,7 @@ Future moveImportantTasksIntoCategory(Category target) {
   );
 }
 
-Future update(Todo entry) {
+Future updateTodo(Todo entry) {
   // using replace will update all fields from the entry that are not marked as a primary key.
   // it will also make sure that only the entry with the same primary key will be updated.
   // Here, this means that the row that has the same id as entry will be updated to reflect


### PR DESCRIPTION
The name of the method update in line 140 Cause exceptions for the methods `moveImportantTasksIntoCategory` and `update` method itself .
The problem is when these two methods try to call the native update method on `package:drift/src/runtime/api/runtime_api.dart` the program use the update method define in this page and trigger exceptions . It takes me lots of time .