### PR TITLE
Add error check for ViewDSL as() declaration

### DIFF
--- a/drift_dev/lib/src/analyzer/dart/view_parser.dart
+++ b/drift_dev/lib/src/analyzer/dart/view_parser.dart
@@ -206,9 +206,17 @@ class ViewParser {
       try {
         final node = await base.loadElementDeclaration(as);
 
-        var target =
-            ((node as MethodDeclaration).body as ExpressionFunctionBody)
-                .expression as MethodInvocation;
+        final body = (node as MethodDeclaration).body;
+        if (body is! ExpressionFunctionBody) {
+          throw analysisError(
+            base.step,
+            element,
+            'The `as()` query declaration must be an expression (=>). '
+            'Block function body `{ return x; }` not acceptable.',
+          );
+        }
+
+        var target = body.expression as MethodInvocation;
 
         for (;;) {
           if (target.target == null) break;


### PR DESCRIPTION
I added new check to view parsing. If somebody declare `as()` query DSL as a function body instead of expression, builder fails with a meaningless `Failed to parse view 'as()' query` error message. 